### PR TITLE
Feature resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added full recovery support, so that agents can restore their boards
+  after they restart. Also added a queue, so that messages are queued
+  if the agent is down. Plus added a wait when looking for agents, so that
+  time is given for an agent to first connect and identify itself. All of
+  this makes the system more robust and reliable, as most jobs are now
+  tolerant of individual agents going down.
+
+- Added a better handshake so that agents communicate both their comms
+  engine details (e.g. paddington version 0.0.25) and their agent
+  engine details (e.g. templemeads version 0.0.25). This will future proof
+  us if we make any future changes to the protocols. Note that this
+  is BREAKING, so agents cannot commnunicate with older versions of
+  openportal
+
+- Added an expiry to jobs, default to 1 minute, that means that both
+  jobs are now cleaned automatically from boards once expired (by a
+  quiet background tokio task), and that putter of jobs can get a signal
+  that the job has expired, and thus return an error, if the job gets
+  lost in the system. This is a breaking change, as the job expiry
+  is a new field. It again significantly improves the robustness of the
+  system, both stopping putters getting stuck indefinitely, and also
+  preventing memory exhaustion by jobs that are never cleaned up. Have
+  set the bridge agent to put jobs with a expiry of 60 minutes, so that
+  there is plenty of time for the web portal to fetch the results without
+  worrying about them being expired.
+
+### Fixed
+
+- General bug fixes and cleaning of output logging to improve resilience
+  and make it easier to debug issues.
+
 
 ## [0.0.25] - 2024-11-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Added
+### Added
 - Added full recovery support, so that agents can restore their boards
   after they restart. Also added a queue, so that messages are queued
   if the agent is down. Plus added a wait when looking for agents, so that

--- a/cluster/src/main.rs
+++ b/cluster/src/main.rs
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
 
 async fn create_account(me: &str, user: &UserIdentifier) -> Result<UserMapping, Error> {
     // find the Account agent
-    match agent::account().await {
+    match agent::account(30).await {
         Some(account) => {
             // send the add_job to the account agent
             let job = Job::parse(
@@ -152,7 +152,7 @@ async fn create_account(me: &str, user: &UserIdentifier) -> Result<UserMapping, 
 
 async fn create_directories(me: &str, mapping: &UserMapping) -> Result<String, Error> {
     // find the Filesystem agent
-    match agent::filesystem().await {
+    match agent::filesystem(30).await {
         Some(filesystem) => {
             // send the add_job to the filesystem agent
             let job = Job::parse(
@@ -189,7 +189,7 @@ async fn create_directories(me: &str, mapping: &UserMapping) -> Result<String, E
 
 async fn update_homedir(me: &str, user: &UserIdentifier, homedir: &str) -> Result<String, Error> {
     // find the Account agent
-    match agent::account().await {
+    match agent::account(30).await {
         Some(account) => {
             // send the add_job to the account agent
             let job = Job::parse(
@@ -236,7 +236,7 @@ async fn add_to_scheduler(
     mapping: &UserMapping,
 ) -> Result<(), Error> {
     // find the Scheduler agent
-    match agent::scheduler().await {
+    match agent::scheduler(30).await {
         Some(scheduler) => {
             // send the add_job to the scheduler agent
             let job = Job::parse(

--- a/paddington/src/command.rs
+++ b/paddington/src/command.rs
@@ -6,16 +6,28 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Command {
-    Error { error: String },
-    Connected { agent: String, zone: String },
-    Disconnected { agent: String, zone: String },
+    Error {
+        error: String,
+    },
+    Connected {
+        agent: String,
+        zone: String,
+        engine: String,
+        version: String,
+    },
+    Disconnected {
+        agent: String,
+        zone: String,
+    },
 }
 
 impl Command {
-    pub fn connected(agent: &str, zone: &str) -> Self {
+    pub fn connected(agent: &str, zone: &str, engine: &str, version: &str) -> Self {
         Self::Connected {
             agent: agent.to_owned(),
             zone: zone.to_owned(),
+            engine: engine.to_owned(),
+            version: version.to_owned(),
         }
     }
 

--- a/paddington/src/eventloop.rs
+++ b/paddington/src/eventloop.rs
@@ -21,6 +21,12 @@ pub async fn run(config: ServiceConfig) -> Result<(), Error> {
     let mut server_handles = vec![];
     let mut client_handles = vec![];
 
+    tracing::info!(
+        "Communication layer: {} version {}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    );
+
     if !config.clients().is_empty() {
         let my_config = config.clone();
         server_handles.push(tokio::spawn(async move { server::run(my_config).await }));

--- a/paddington/src/exchange.rs
+++ b/paddington/src/exchange.rs
@@ -192,13 +192,9 @@ pub async fn unregister(connection: &Connection) -> Result<(), Error> {
 
     if exchange.connections.contains_key(&key) {
         exchange.connections.remove(&key);
-        Ok(())
-    } else {
-        Err(Error::UnnamedConnection(format!(
-            "Connection {} not found",
-            key
-        )))
     }
+
+    Ok(())
 }
 
 pub async fn register(connection: Connection) -> Result<(), Error> {

--- a/paddington/src/lib.rs
+++ b/paddington/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub use crypto::{Key, SecretKey, Signature};
 pub use error::Error;
 pub use eventloop::run;
+pub use exchange::received;
 pub use exchange::send;
 pub use exchange::set_handler;
 pub mod invite;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -384,6 +384,11 @@ impl Job {
     }
 
     fn update(&mut self) -> PyResult<()> {
+        // don't update if the job is already finished
+        if self.is_finished()? {
+            return Ok(());
+        }
+
         match status(self.clone()) {
             Ok(updated) => {
                 *self = updated;

--- a/templemeads/src/board.rs
+++ b/templemeads/src/board.rs
@@ -11,6 +11,11 @@ use crate::command::Command as ControlCommand;
 use crate::error::Error;
 use crate::job::Job;
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct SyncState {
+    jobs: Vec<Job>,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Board {
     peer: Peer,
@@ -44,6 +49,16 @@ impl Board {
             jobs: HashMap::new(),
             queued_commands: Vec::new(),
             waiters: HashMap::new(),
+        }
+    }
+
+    ///
+    /// Return the sync state that can be used to synchronise this board
+    /// with its copy on the peer
+    ///
+    pub fn sync_state(&self) -> SyncState {
+        SyncState {
+            jobs: self.jobs.values().cloned().collect(),
         }
     }
 

--- a/templemeads/src/board.rs
+++ b/templemeads/src/board.rs
@@ -16,6 +16,12 @@ pub struct SyncState {
     jobs: Vec<Job>,
 }
 
+impl SyncState {
+    pub fn jobs(&self) -> &Vec<Job> {
+        &self.jobs
+    }
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Board {
     peer: Peer,

--- a/templemeads/src/bridge.rs
+++ b/templemeads/src/bridge.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 pub async fn status(job: &Uuid) -> Result<Job, Error> {
     tracing::info!("Received status request for job: {}", job);
 
-    match agent::portal().await {
+    match agent::portal(30).await {
         Some(portal) => {
             // get the (shared) board for the portal
             let board = match state::get(&portal).await {
@@ -44,7 +44,7 @@ pub async fn run(command: &str) -> Result<Job, Error> {
 
     let my_name = agent::name().await;
 
-    match agent::portal().await {
+    match agent::portal(30).await {
         Some(portal) => {
             let job = Job::parse(command, true)?;
 

--- a/templemeads/src/bridge.rs
+++ b/templemeads/src/bridge.rs
@@ -61,12 +61,18 @@ pub async fn run(command: &str) -> Result<Job, Error> {
                 )));
             }
 
-            Ok(Job::parse(
+            let job = Job::parse(
                 &format!("{}.{} submit {}", my_name, portal.name(), command),
                 true,
-            )?
-            .put(&portal)
-            .await?)
+            )?;
+
+            // use a longer duration for this job so that there is plenty of
+            // time for the portal to collect the result - in reality, the
+            // actual job on the system will have a much shorter lifetime,
+            // e.g. 1 minute
+            let job = job.set_lifetime(chrono::Duration::minutes(60));
+
+            Ok(job.put(&portal).await?)
         }
         None => {
             tracing::error!("No portal agent found");

--- a/templemeads/src/command.rs
+++ b/templemeads/src/command.rs
@@ -15,12 +15,26 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Command {
-    Error { error: String },
-    Put { job: Job },
-    Update { job: Job },
-    Delete { job: Job },
-    Register { agent: AgentType },
-    Sync { state: SyncState },
+    Error {
+        error: String,
+    },
+    Put {
+        job: Job,
+    },
+    Update {
+        job: Job,
+    },
+    Delete {
+        job: Job,
+    },
+    Register {
+        agent: AgentType,
+        engine: String,
+        version: String,
+    },
+    Sync {
+        state: SyncState,
+    },
 }
 
 impl std::fmt::Display for Command {
@@ -30,7 +44,15 @@ impl std::fmt::Display for Command {
             Command::Put { job } => write!(f, "Put: {}", job),
             Command::Update { job } => write!(f, "Update: {}", job),
             Command::Delete { job } => write!(f, "Delete: {}", job),
-            Command::Register { agent } => write!(f, "Register: {}", agent),
+            Command::Register {
+                agent,
+                engine,
+                version,
+            } => write!(
+                f,
+                "Register: {}, engine={} version={}",
+                agent, engine, version
+            ),
             Command::Sync { state: _ } => write!(f, "Sync: State"),
         }
     }
@@ -55,9 +77,11 @@ impl Command {
         }
     }
 
-    pub fn register(agent: &AgentType) -> Self {
+    pub fn register(agent: &AgentType, engine: &str, version: &str) -> Self {
         Self::Register {
             agent: agent.clone(),
+            engine: engine.to_owned(),
+            version: version.to_owned(),
         }
     }
 
@@ -93,7 +117,11 @@ impl Command {
             Command::Update { job } => Some(job.clone()),
             Command::Delete { job } => Some(job.clone()),
             Command::Sync { state: _ } => None,
-            Command::Register { agent: _ } => None,
+            Command::Register {
+                agent: _,
+                engine: _,
+                version: _,
+            } => None,
             Command::Error { error: _ } => None,
         }
     }
@@ -104,7 +132,11 @@ impl Command {
             Command::Update { job } => Some(job.id()),
             Command::Delete { job } => Some(job.id()),
             Command::Sync { state: _ } => None,
-            Command::Register { agent: _ } => None,
+            Command::Register {
+                agent: _,
+                engine: _,
+                version: _,
+            } => None,
             Command::Error { error: _ } => None,
         }
     }
@@ -168,7 +200,16 @@ mod tests {
     #[test]
     fn test_command_register() {
         let agent = AgentType::Portal;
-        let command = Command::register(&agent);
-        assert_eq!(command, Command::Register { agent });
+        let engine = "templemeads";
+        let version = "0.0.10";
+        let command = Command::register(&agent, engine, version);
+        assert_eq!(
+            command,
+            Command::Register {
+                agent,
+                engine: engine.to_owned(),
+                version: version.to_owned()
+            }
+        );
     }
 }

--- a/templemeads/src/command.rs
+++ b/templemeads/src/command.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::agent::{Peer, Type as AgentType};
+use crate::board::SyncState;
 use crate::error::Error;
 use crate::job::Job;
 
@@ -18,6 +19,7 @@ pub enum Command {
     Update { job: Job },
     Delete { job: Job },
     Register { agent: AgentType },
+    Sync { state: SyncState },
 }
 
 impl std::fmt::Display for Command {
@@ -28,6 +30,7 @@ impl std::fmt::Display for Command {
             Command::Update { job } => write!(f, "Update: {}", job),
             Command::Delete { job } => write!(f, "Delete: {}", job),
             Command::Register { agent } => write!(f, "Register: {}", agent),
+            Command::Sync { state: _ } => write!(f, "Sync: State"),
         }
     }
 }
@@ -57,6 +60,12 @@ impl Command {
         }
     }
 
+    pub fn sync(state: &SyncState) -> Self {
+        Self::Sync {
+            state: state.clone(),
+        }
+    }
+
     pub async fn send_to(&self, peer: &Peer) -> Result<(), Error> {
         Ok(send_to_peer(Message::send_to(
             peer.name(),
@@ -71,6 +80,7 @@ impl Command {
             Command::Put { job } => Some(job.clone()),
             Command::Update { job } => Some(job.clone()),
             Command::Delete { job } => Some(job.clone()),
+            Command::Sync { state: _ } => None,
             Command::Register { agent: _ } => None,
             Command::Error { error: _ } => None,
         }
@@ -81,6 +91,7 @@ impl Command {
             Command::Put { job } => Some(job.id()),
             Command::Update { job } => Some(job.id()),
             Command::Delete { job } => Some(job.id()),
+            Command::Sync { state: _ } => None,
             Command::Register { agent: _ } => None,
             Command::Error { error: _ } => None,
         }

--- a/templemeads/src/command.rs
+++ b/templemeads/src/command.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use paddington::message::Message;
 use paddington::send as send_to_peer;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Command {
@@ -63,6 +64,26 @@ impl Command {
             &serde_json::to_string(self)?,
         ))
         .await?)
+    }
+
+    pub fn job(&self) -> Option<Job> {
+        match self {
+            Command::Put { job } => Some(job.clone()),
+            Command::Update { job } => Some(job.clone()),
+            Command::Delete { job } => Some(job.clone()),
+            Command::Register { agent: _ } => None,
+            Command::Error { error: _ } => None,
+        }
+    }
+
+    pub fn job_id(&self) -> Option<Uuid> {
+        match self {
+            Command::Put { job } => Some(job.id()),
+            Command::Update { job } => Some(job.id()),
+            Command::Delete { job } => Some(job.id()),
+            Command::Register { agent: _ } => None,
+            Command::Error { error: _ } => None,
+        }
     }
 }
 

--- a/templemeads/src/command.rs
+++ b/templemeads/src/command.rs
@@ -75,6 +75,15 @@ impl Command {
         .await?)
     }
 
+    pub async fn received_from(&self, peer: &Peer) -> Result<(), Error> {
+        Ok(received(Message::received_from(
+            peer.name(),
+            peer.zone(),
+            &serde_json::to_string(self)?,
+        ))
+        .await?)
+    }
+
     pub fn job(&self) -> Option<Job> {
         match self {
             Command::Put { job } => Some(job.clone()),

--- a/templemeads/src/command.rs
+++ b/templemeads/src/command.rs
@@ -8,6 +8,7 @@ use crate::job::Job;
 
 use anyhow::Result;
 use paddington::message::Message;
+use paddington::received as received_from_peer;
 use paddington::send as send_to_peer;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -75,13 +76,15 @@ impl Command {
         .await?)
     }
 
-    pub async fn received_from(&self, peer: &Peer) -> Result<(), Error> {
-        Ok(received(Message::received_from(
+    pub fn received_from(&self, peer: &Peer) -> Result<(), Error> {
+        match received_from_peer(Message::received_from(
             peer.name(),
             peer.zone(),
             &serde_json::to_string(self)?,
-        ))
-        .await?)
+        )) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(Error::from(e)),
+        }
     }
 
     pub fn job(&self) -> Option<Job> {

--- a/templemeads/src/control_message.rs
+++ b/templemeads/src/control_message.rs
@@ -19,7 +19,12 @@ pub async fn process_control_message(
             tracing::info!("Connected to agent: {}", peer);
             Command::register(agent_type).send_to(&peer).await?;
 
-            // now we need to send all of the queued jobs for this peer
+            // now send the current board to the peer, so that they
+            // can restore their state
+            job::sync_board(&peer).await?;
+
+            // now they have their new state, we need to send all of the
+            // queued jobs for this peer
             job::send_queued(&peer).await?;
         }
         ControlCommand::Disconnected { agent, zone } => {

--- a/templemeads/src/control_message.rs
+++ b/templemeads/src/control_message.rs
@@ -4,6 +4,7 @@
 use crate::agent::{Peer, Type as AgentType};
 use crate::command::Command;
 use crate::error::Error;
+use crate::job;
 
 use anyhow::Result;
 use paddington::command::Command as ControlCommand;
@@ -17,6 +18,9 @@ pub async fn process_control_message(
             let peer = Peer::new(&agent, &zone);
             tracing::info!("Connected to agent: {}", peer);
             Command::register(agent_type).send_to(&peer).await?;
+
+            // now we need to send all of the queued jobs for this peer
+            job::send_queued(&peer).await?;
         }
         ControlCommand::Disconnected { agent, zone } => {
             let peer = Peer::new(&agent, &zone);

--- a/templemeads/src/control_message.rs
+++ b/templemeads/src/control_message.rs
@@ -14,10 +14,21 @@ pub async fn process_control_message(
     command: ControlCommand,
 ) -> Result<(), Error> {
     match command {
-        ControlCommand::Connected { agent, zone } => {
+        ControlCommand::Connected {
+            agent,
+            zone,
+            engine: _,
+            version: _,
+        } => {
             let peer = Peer::new(&agent, &zone);
             tracing::info!("Connected to agent: {}", peer);
-            Command::register(agent_type).send_to(&peer).await?;
+            Command::register(
+                agent_type,
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION"),
+            )
+            .send_to(&peer)
+            .await?;
 
             // now send the current board to the peer, so that they
             // can restore their state

--- a/templemeads/src/error.rs
+++ b/templemeads/src/error.rs
@@ -49,6 +49,9 @@ pub enum Error {
     InvalidState(String),
 
     #[error("{0}")]
+    Expired(String),
+
+    #[error("{0}")]
     LockError(String),
 
     #[error("{0}")]

--- a/templemeads/src/handler.rs
+++ b/templemeads/src/handler.rs
@@ -208,7 +208,6 @@ async_message_handler! {
         match message.typ() {
             MessageType::Control => {
                 process_control_message(&service_info.agent_type, message.into()).await?;
-
                 Ok(())
             }
             MessageType::KeepAlive => {

--- a/templemeads/src/handler.rs
+++ b/templemeads/src/handler.rs
@@ -42,6 +42,12 @@ pub async fn set_my_service_details(
     agent_type: &agent::Type,
     runner: Option<AsyncRunnable>,
 ) -> Result<()> {
+    tracing::info!(
+        "Agent layer: {} version {}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    );
+
     agent::register_self(service, agent_type).await;
     let mut service_details = SERVICE_DETAILS.write().await;
     service_details.service = service.to_string();

--- a/templemeads/src/handler.rs
+++ b/templemeads/src/handler.rs
@@ -190,6 +190,9 @@ async fn process_command(
                 }
             }
         }
+        Command::Sync { state } => {
+            tracing::info!("Syncing state: {:?}", state);
+        }
         _ => {
             tracing::warn!("Command {} not recognised", command);
         }

--- a/templemeads/src/handler.rs
+++ b/templemeads/src/handler.rs
@@ -97,7 +97,7 @@ async fn process_command(
                     }
                 }
                 Position::Destination => {
-                    tracing::info!("Job has arrived at its destination: {}", job);
+                    tracing::info!("Updated job has arrived at its destination: {}", job);
                 }
                 Position::Error => {
                     tracing::error!("Job has got into an errored position: {}", job);
@@ -192,7 +192,7 @@ async fn process_command(
         }
         Command::Sync { state } => {
             let peer = Peer::new(sender, zone);
-            sync_from_peer(&recipient, &peer, state).await?;
+            sync_from_peer(recipient, &peer, state).await?;
         }
         _ => {
             tracing::warn!("Command {} not recognised", command);

--- a/templemeads/src/handler.rs
+++ b/templemeads/src/handler.rs
@@ -7,7 +7,7 @@ use crate::command::Command;
 use crate::control_message::process_control_message;
 use crate::destination::Position;
 use crate::error::Error;
-use crate::job::Envelope;
+use crate::job::{sync_from_peer, Envelope};
 use crate::runnable::{default_runner, AsyncRunnable};
 
 use anyhow::Result;
@@ -191,7 +191,8 @@ async fn process_command(
             }
         }
         Command::Sync { state } => {
-            tracing::info!("Syncing state: {:?}", state);
+            let peer = Peer::new(sender, zone);
+            sync_from_peer(&recipient, &peer, state).await?;
         }
         _ => {
             tracing::warn!("Command {} not recognised", command);

--- a/templemeads/src/handler.rs
+++ b/templemeads/src/handler.rs
@@ -7,7 +7,7 @@ use crate::command::Command;
 use crate::control_message::process_control_message;
 use crate::destination::Position;
 use crate::error::Error;
-use crate::job::{sync_from_peer, Envelope};
+use crate::job::{sync_from_peer, Envelope, Status};
 use crate::runnable::{default_runner, AsyncRunnable};
 
 use anyhow::Result;
@@ -74,9 +74,18 @@ async fn process_command(
     runner: &AsyncRunnable,
 ) -> Result<(), Error> {
     match command {
-        Command::Register { agent } => {
-            tracing::info!("Registering agent: {}", agent);
-            agent::register_peer(&Peer::new(sender, zone), agent).await;
+        Command::Register {
+            agent,
+            engine,
+            version,
+        } => {
+            tracing::info!(
+                "Registering agent: {}, engine={} version={}",
+                agent,
+                engine,
+                version
+            );
+            agent::register_peer(&Peer::new(sender, zone), agent, engine, version).await;
         }
         Command::Update { job } => {
             let peer = Peer::new(sender, zone);
@@ -92,14 +101,18 @@ async fn process_command(
                     // if we are upstream, then the job is moving backwards so we need to
                     // send it to the previous agent
                     if let Some(agent) = job.destination().previous(recipient) {
-                        let _ = job.update(&Peer::new(&agent, zone)).await?;
+                        let peer = Peer::new(&agent, zone);
+                        agent::wait_for(&peer, 30).await?;
+                        job.update(&peer).await?;
                     }
                 }
                 Position::Downstream => {
                     // if we are downstream, then we continue to let the job
                     // flow downstream
                     if let Some(agent) = job.destination().next(recipient) {
-                        let _ = job.update(&Peer::new(&agent, zone)).await?;
+                        let peer = Peer::new(&agent, zone);
+                        agent::wait_for(&peer, 30).await?;
+                        job.update(&peer).await?;
                     }
                 }
                 Position::Destination => {
@@ -131,7 +144,10 @@ async fn process_command(
                     // if we are downstream, then we continue to let the job
                     // flow downstream
                     if let Some(agent) = job.destination().next(recipient) {
-                        job = match job.put(&Peer::new(&agent, zone)).await {
+                        let peer = Peer::new(&agent, zone);
+                        agent::wait_for(&peer, 30).await?;
+
+                        job = match job.put(&peer).await {
                             Ok(job) => job,
                             Err(e) => {
                                 tracing::error!("Error putting job: {}", e);
@@ -142,13 +158,23 @@ async fn process_command(
                 }
                 Position::Destination => {
                     // we are the destination, so we need to take action
-                    job = match runner(Envelope::new(recipient, sender, zone, &job)).await {
-                        Ok(job) => job,
-                        Err(e) => {
-                            tracing::error!("Error running job: {}", e);
-                            job.errored(&e.to_string())?
+                    match job.state() {
+                        Status::Complete => {
+                            tracing::info!("Not rerunning job that has already completed: {}", job);
                         }
-                    };
+                        Status::Error => {
+                            tracing::error!("Not rerunning job that has already errored: {}", job);
+                        }
+                        _ => {
+                            job = match runner(Envelope::new(recipient, sender, zone, &job)).await {
+                                Ok(job) => job,
+                                Err(e) => {
+                                    tracing::error!("Error running job: {}", e);
+                                    job.errored(&e.to_string())?
+                                }
+                            };
+                        }
+                    }
                 }
                 Position::Error => {
                     tracing::error!("Job has got into an errored position: {}", job);
@@ -163,7 +189,10 @@ async fn process_command(
             tracing::info!("Job has finished: {}", job);
 
             // now the job has finished, update the sender's board
-            let _ = job.update(&Peer::new(sender, zone)).await?;
+            let peer = Peer::new(sender, zone);
+            agent::wait_for(&peer, 30).await?;
+
+            let _ = job.update(&peer).await?;
         }
         Command::Delete { job } => {
             let peer = Peer::new(sender, zone);
@@ -178,14 +207,18 @@ async fn process_command(
                     // if we are upstream, then the job is moving backwards so we need to
                     // send it to the previous agent
                     if let Some(agent) = job.destination().previous(recipient) {
-                        let _ = job.delete(&Peer::new(&agent, zone)).await?;
+                        let peer = Peer::new(&agent, zone);
+                        agent::wait_for(&peer, 30).await?;
+                        job.delete(&peer).await?;
                     }
                 }
                 Position::Downstream => {
                     // if we are downstream, then we continue to let the job
                     // flow downstream
                     if let Some(agent) = job.destination().next(recipient) {
-                        let _ = job.delete(&Peer::new(&agent, zone)).await?;
+                        let peer = Peer::new(&agent, zone);
+                        agent::wait_for(&peer, 30).await?;
+                        job.delete(&peer).await?;
                     }
                 }
                 Position::Error => {

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -171,6 +171,8 @@ pub struct Job {
     created: chrono::DateTime<Utc>,
     #[serde(with = "ts_seconds")]
     changed: chrono::DateTime<Utc>,
+    #[serde(with = "ts_seconds")]
+    expires: chrono::DateTime<Utc>,
     version: u64,
     command: Command,
     state: Status,
@@ -200,6 +202,11 @@ impl Job {
             id: Uuid::new_v4(),
             created: now,
             changed: now,
+            // settled on 1 minute as this makes the interface with the
+            // user portal more responsive - any task that takes longer
+            // than a minute can have its lifetime changed using the
+            // set_lifetime method
+            expires: now + chrono::Duration::minutes(1),
             version: 1,
             command: Command::parse(command, check_portal)?,
             state: Status::Created,
@@ -218,6 +225,24 @@ impl Job {
 
     pub fn instruction(&self) -> Instruction {
         self.command.instruction()
+    }
+
+    pub fn set_lifetime(&self, lifetime: chrono::Duration) -> Self {
+        Self {
+            id: self.id,
+            created: self.created,
+            changed: self.changed,
+            expires: self.created + lifetime,
+            version: self.version,
+            command: self.command.clone(),
+            state: self.state.clone(),
+            result: self.result.clone(),
+            board: self.board.clone(),
+        }
+    }
+
+    pub fn is_expired(&self) -> bool {
+        self.expires < Utc::now()
     }
 
     pub fn is_finished(&self) -> bool {
@@ -245,6 +270,7 @@ impl Job {
             id: self.id,
             created: self.created,
             changed: Utc::now(),
+            expires: self.expires,
             version: self.version + 1,
             command: self.command.clone(),
             state: self.state.clone(),
@@ -275,12 +301,23 @@ impl Job {
         }
     }
 
+    pub fn assert_is_not_expired(&self) -> Result<(), Error> {
+        if self.is_expired() {
+            Err(Error::Expired(
+                format!("Job {} has expired", self.id).to_owned(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     pub fn pending(&self) -> Result<Job, Error> {
         match self.state {
             Status::Created => Ok(Job {
                 id: self.id,
                 created: self.created,
                 changed: Utc::now(),
+                expires: self.expires,
                 version: self.version + 1,
                 command: self.command.clone(),
                 state: Status::Pending,
@@ -300,6 +337,7 @@ impl Job {
                 id: self.id,
                 created: self.created,
                 changed: Utc::now(),
+                expires: self.expires,
                 version: self.version + 1,
                 command: self.command.clone(),
                 state: Status::Running,
@@ -321,6 +359,7 @@ impl Job {
                 id: self.id,
                 created: self.created,
                 changed: Utc::now(),
+                expires: self.expires,
                 version: self.version + 1000, // make sure this is the newest version
                 command: self.command.clone(),
                 state: Status::Complete,
@@ -339,6 +378,7 @@ impl Job {
                 id: self.id,
                 created: self.created,
                 changed: Utc::now(),
+                expires: self.expires,
                 version: self.version + 1000, // make sure this is the newest version
                 command: self.command.clone(),
                 state: Status::Error,
@@ -398,6 +438,8 @@ impl Job {
     }
 
     pub async fn execute(&self) -> Result<Job, Error> {
+        self.assert_is_not_expired()?;
+
         match self.state() {
             Status::Pending => {
                 tracing::info!("Running job.execute() for job: {:?}", self);
@@ -415,6 +457,8 @@ impl Job {
                 format!("A created job should not have been received? {:?}", self).to_owned(),
             ));
         }
+
+        self.assert_is_not_expired()?;
 
         let mut job = self.clone();
 
@@ -452,6 +496,8 @@ impl Job {
     }
 
     pub async fn put(&self, peer: &Peer) -> Result<Job, Error> {
+        self.assert_is_not_expired()?;
+
         // transition the job to pending, recording where it was sent
         let mut job = self.pending()?;
 
@@ -501,6 +547,8 @@ impl Job {
     }
 
     pub async fn updated(&self) -> Result<Job, Error> {
+        self.assert_is_not_expired()?;
+
         let agent = match self.board {
             Some(ref a) => a,
             None => {
@@ -542,6 +590,8 @@ impl Job {
     }
 
     pub async fn update(&self, peer: &Peer) -> Result<Job, Error> {
+        self.assert_is_not_expired()?;
+
         let mut job = self.clone();
 
         // get a RwLock to the board from the shared state
@@ -589,6 +639,8 @@ impl Job {
     }
 
     pub async fn deleted(&self, peer: &Peer) -> Result<Job, Error> {
+        self.assert_is_not_expired()?;
+
         let mut job = self.clone();
 
         // get a RwLock to the board from the shared state
@@ -626,6 +678,8 @@ impl Job {
     }
 
     pub async fn delete(&self, peer: &Peer) -> Result<Job, Error> {
+        self.assert_is_not_expired()?;
+
         let mut job = self.clone();
 
         // get a RwLock to the board from the shared state
@@ -770,6 +824,8 @@ pub async fn sync_from_peer(recipient: &str, peer: &Peer, sync: &SyncState) -> R
     let mut update_jobs = Vec::new();
     let mut put_jobs = Vec::new();
 
+    let mut num_synced = 0;
+
     // loop over all of the jobs in the sync state and process them
     {
         // get a RwLock to the board from the shared state
@@ -789,25 +845,36 @@ pub async fn sync_from_peer(recipient: &str, peer: &Peer, sync: &SyncState) -> R
         // loop through each job and see if we have them already in the board?
         for job in jobs {
             if board.would_be_changed_by(job) {
-                // the board would be changed by this job - we now need to work
-                // out if this is a put or an update. Assume that it is a put
-                // if the job is moving downstream or we are the destination,
-                // or an update if moving upstream
-                match job.destination().position(recipient, peer.name()) {
-                    Position::Upstream => {
+                match job.state() {
+                    Status::Complete => {
+                        // we don't need to run this again, so just update
                         update_jobs.push(job);
                     }
-                    Position::Downstream => {
-                        put_jobs.push(job);
+                    Status::Error => {
+                        // we don't need to run this again, so just update
+                        update_jobs.push(job);
                     }
-                    Position::Destination => {
-                        put_jobs.push(job);
-                    }
-                    _ => {
-                        tracing::error!("Job has got into an errored position: {:?}", job);
-                        tracing::error!("Ignoring this job during the state update");
-                    }
+                    _ => match job.destination().position(recipient, peer.name()) {
+                        Position::Upstream => {
+                            // sending the results back up to the putter
+                            update_jobs.push(job);
+                        }
+                        Position::Downstream => {
+                            // putting the job down to the destination
+                            put_jobs.push(job);
+                        }
+                        Position::Destination => {
+                            // we are the destination, so re-run the job
+                            put_jobs.push(job);
+                        }
+                        _ => {
+                            tracing::error!("Job has got into an errored position: {:?}", job);
+                            tracing::error!("Ignoring this job during the state update");
+                        }
+                    },
                 }
+            } else {
+                tracing::info!("Already have job: {} on the board", job);
             }
         }
     }
@@ -815,23 +882,39 @@ pub async fn sync_from_peer(recipient: &str, peer: &Peer, sync: &SyncState) -> R
     // ok - we now have all of the put and updates - send all the
     // updates first, then the puts
     for job in update_jobs {
-        match ControlCommand::update(&job).send_to_self_from(peer).await {
-            Ok(_) => (),
-            Err(e) => {
-                tracing::error!("Error sending update command to agent: {:?}", e);
-                tracing::error!("Ignoring this job during the state update");
+        if !job.is_expired() {
+            tracing::info!("Updating job: {}", job);
+            num_synced += 1;
+
+            match ControlCommand::update(job).received_from(peer) {
+                Ok(_) => (),
+                Err(e) => {
+                    tracing::error!("Error sending update command to agent: {:?}", e);
+                    tracing::error!("Ignoring this job during the state update");
+                }
             }
         }
     }
 
     for job in put_jobs {
-        match ControlCommand::put(&job).send_to_self_from(peer).await {
-            Ok(_) => (),
-            Err(e) => {
-                tracing::error!("Error sending put command to agent: {:?}", e);
-                tracing::error!("Ignoring this job during the state update");
+        if !job.is_expired() {
+            tracing::info!("Putting job: {}", job);
+            num_synced += 1;
+
+            match ControlCommand::put(job).received_from(peer) {
+                Ok(_) => (),
+                Err(e) => {
+                    tracing::error!("Error sending put command to agent: {:?}", e);
+                    tracing::error!("Ignoring this job during the state update");
+                }
             }
         }
+    }
+
+    match num_synced {
+        0 => tracing::info!("No jobs synced from peer {}", peer),
+        1 => tracing::info!("1 job synced from peer {}", peer),
+        _ => tracing::info!("{} jobs synced from peer {}", num_synced, peer),
     }
 
     Ok(())

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -439,7 +439,13 @@ impl Job {
             // add the job to the board - we need to set our board to the agent
             // first, so that the board can check it is correct
             job.board = Some(peer.clone());
-            board.add(&job)?;
+
+            if !board.add(&job)? {
+                // The board already contains this version of the job
+                // There is no change, so no need to send to the peer
+                // (the job has already been sent)
+                return Ok(job);
+            }
         }
 
         Ok(job)
@@ -470,7 +476,13 @@ impl Job {
             // add the job to the board - we need to set our board to the agent
             // first, so that the board can check it is correct
             job.board = Some(peer.clone());
-            board.add(&job)?;
+
+            if !board.add(&job)? {
+                // The board already contains this version of the job
+                // There is no change, so no need to send to the peer
+                // (the job has already been sent)
+                return Ok(job);
+            }
         }
 
         // now send it to the agent for processing
@@ -518,7 +530,12 @@ impl Job {
 
             // add the job to the board - we need to set our board to the agent
             // first, so that the board can check it is correct
-            board.add(self)?;
+            if !board.add(self)? {
+                // The board already contains this version of the job
+                // There is no change, so no need to send to the peer
+                // (the job has already been sent)
+                return Ok(self.clone());
+            }
         }
 
         Ok(self.clone())
@@ -548,7 +565,12 @@ impl Job {
             // add the job to the board - we need to set our board to the agent
             // first, so that the board can check it is correct
             job.board = Some(peer.clone());
-            board.add(&job)?;
+            if !board.add(&job)? {
+                // The board already contains this version of the job
+                // There is no change, so no need to send to the peer
+                // (the job has already been sent)
+                return Ok(job);
+            }
         }
 
         // now send it to the agent for processing
@@ -589,8 +611,15 @@ impl Job {
 
             // remove the job to the board
             job.board = Some(peer.clone());
-            board.remove(&job)?;
+            let changed = board.remove(&job)?;
             job.board = None;
+
+            if !changed {
+                // The board already contains this version of the job
+                // There is no change, so no need to send to the peer
+                // (the job has already been sent)
+                return Ok(job);
+            }
         }
 
         Ok(job)
@@ -619,8 +648,15 @@ impl Job {
 
             // remove the job from the board
             job.board = Some(peer.clone());
-            board.remove(&job)?;
+            let changed = board.remove(&job)?;
             job.board = None;
+
+            if !changed {
+                // The board already contains this version of the job
+                // There is no change, so no need to send to the peer
+                // (the job has already been sent)
+                return Ok(job);
+            }
         }
 
         // now send it to the agent for processing

--- a/templemeads/src/portal.rs
+++ b/templemeads/src/portal.rs
@@ -66,7 +66,7 @@ crate::async_runnable! {
                 }
 
                 // who is next in line to receive this job? - find it, and its zone
-                let next_agent = agent::find(&destination.agents()[1]).await.ok_or_else(|| {
+                let next_agent = agent::find(&destination.agents()[1], 30).await.ok_or_else(|| {
                     Error::InvalidInstruction(
                         format!("Invalid instruction: {}. Cannot find next agent in destination {}",
                                 job.instruction(), destination),

--- a/templemeads/src/state.rs
+++ b/templemeads/src/state.rs
@@ -19,9 +19,49 @@ static STATES: Lazy<RwLock<States>> = Lazy::new(|| RwLock::new(States::new()));
 
 impl States {
     fn new() -> Self {
+        start_cleaner();
+
         Self {
             states: HashMap::new(),
         }
+    }
+}
+
+///
+/// Function called in a tokio task to clean up the boards
+///
+fn start_cleaner() {
+    tokio::spawn(async {
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+            clean_boards().await;
+        }
+    });
+}
+
+///
+/// Call this function to clean up the expired jobs from the boards
+///
+async fn clean_boards() {
+    let peers = STATES
+        .read()
+        .await
+        .states
+        .keys()
+        .cloned()
+        .collect::<Vec<Peer>>();
+
+    for peer in peers.iter() {
+        let state = match get(peer).await {
+            Ok(state) => state,
+            Err(e) => {
+                tracing::error!("Error getting state for {}: {}", peer, e);
+                continue;
+            }
+        };
+
+        let board = state.board().await;
+        board.write().await.remove_expired_jobs();
     }
 }
 

--- a/templemeads/src/state.rs
+++ b/templemeads/src/state.rs
@@ -54,6 +54,8 @@ pub struct State {
 
 impl State {
     pub fn new(peer: Peer) -> Self {
+        tracing::info!("Creating new board for agent {}", peer);
+
         Self {
             board: Arc::new(RwLock::new(Board::new(&peer))),
         }


### PR DESCRIPTION
### Added
- Added full recovery support, so that agents can restore their boards
  after they restart. Also added a queue, so that messages are queued
  if the agent is down. Plus added a wait when looking for agents, so that
  time is given for an agent to first connect and identify itself. All of
  this makes the system more robust and reliable, as most jobs are now
  tolerant of individual agents going down.

- Added a better handshake so that agents communicate both their comms
  engine details (e.g. paddington version 0.0.25) and their agent
  engine details (e.g. templemeads version 0.0.25). This will future proof
  us if we make any future changes to the protocols. Note that this
  is BREAKING, so agents cannot commnunicate with older versions of
  openportal

- Added an expiry to jobs, default to 1 minute, that means that both
  jobs are now cleaned automatically from boards once expired (by a
  quiet background tokio task), and that putter of jobs can get a signal
  that the job has expired, and thus return an error, if the job gets
  lost in the system. This is a breaking change, as the job expiry
  is a new field. It again significantly improves the robustness of the
  system, both stopping putters getting stuck indefinitely, and also
  preventing memory exhaustion by jobs that are never cleaned up. Have
  set the bridge agent to put jobs with a expiry of 60 minutes, so that
  there is plenty of time for the web portal to fetch the results without
  worrying about them being expired.

### Fixed

- General bug fixes and cleaning of output logging to improve resilience
  and make it easier to debug issues.
