### PR TITLE
Feature sactmgr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   there is plenty of time for the web portal to fetch the results without
   worrying about them being expired.
 
+- Added a command line support for the slurm agent, so that it can use
+  `sacctmgr` to create accounts on slurm in addition to the REST API.
+  You choose the command line option by not setting the `slurm-server`
+  value in the config file.
+
 ### Fixed
 
 - General bug fixes and cleaning of output logging to improve resilience

--- a/slurm/src/cache.rs
+++ b/slurm/src/cache.rs
@@ -20,9 +20,18 @@ struct Database {
 
 static CACHE: Lazy<RwLock<Database>> = Lazy::new(|| RwLock::new(Database::default()));
 
-pub async fn get_cluster() -> Result<Option<String>, Error> {
+pub async fn get_option_cluster() -> Result<Option<String>, Error> {
     let cache = CACHE.read().await;
     Ok(cache.cluster.clone())
+}
+
+pub async fn get_cluster() -> Result<String, Error> {
+    let cache = CACHE.read().await;
+
+    match cache.cluster {
+        Some(ref cluster) => Ok(cluster.clone()),
+        None => Ok("linux".to_string()),
+    }
 }
 
 pub async fn set_cluster(cluster: &str) -> Result<(), Error> {

--- a/slurm/src/main.rs
+++ b/slurm/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> Result<()> {
         let scontrol_command = config.option("scontrol", "scontrol");
 
         sacctmgr::set_commands(&sacctmgr_command, &scontrol_command).await;
+        sacctmgr::find_cluster().await?;
 
         async_runnable! {
             ///

--- a/slurm/src/main.rs
+++ b/slurm/src/main.rs
@@ -69,6 +69,13 @@ async fn main() -> Result<()> {
     if slurm_server.is_empty() {
         // we are using sacctmgr and the commandline to interact
         // with slurm, because slurmrestd is not available
+
+        // get the sacctmgr and scontrol commands
+        let sacctmgr_command = config.option("sacctmgr", "sacctmgr");
+        let scontrol_command = config.option("scontrol", "scontrol");
+
+        sacctmgr::set_commands(&sacctmgr_command, &scontrol_command).await;
+
         async_runnable! {
             ///
             /// Runnable function that will be called when a job is received

--- a/slurm/src/main.rs
+++ b/slurm/src/main.rs
@@ -11,6 +11,7 @@ use templemeads::job::{Envelope, Job};
 use templemeads::Error;
 
 mod cache;
+mod sacctmgr;
 mod slurm;
 
 ///
@@ -57,83 +58,116 @@ async fn main() -> Result<()> {
     };
 
     // get the extra options needed for the slurm scheduler
-    let token_command = config.option("token-command", "");
-    let slurm_server = config.option("slurm-server", "");
-    let slurm_user = config.option("slurm-user", "");
     let slurm_cluster = config.option("slurm-cluster", "");
-    let token_lifespan = config.option("token-lifespan", "1800");
-
-    let mut token_lifespan: u32 = match token_lifespan.parse() {
-        Ok(lifespan) => lifespan,
-        Err(_) => {
-            return Err(anyhow::anyhow!(
-                "Invalid token lifespan provided. This should be a number of seconds.".to_owned(),
-            ));
-        }
-    };
-
-    if token_lifespan < 10 {
-        tracing::warn!("Cannot set the token lifespan to less than 10 seconds.");
-        tracing::warn!("Setting it to a minimum of 10 seconds...");
-        token_lifespan = 10;
-    }
-
-    if token_command.is_empty() {
-        return Err(anyhow::anyhow!(
-            "No token command provided. This should be the command needed to \
-             generate a valid JWT token. Set this in the token-command \
-             option."
-                .to_owned(),
-        ));
-    }
-
-    if slurm_server.is_empty() {
-        return Err(anyhow::anyhow!(
-            "No Slurm server specified. Please set this in the slurm-server option.".to_owned(),
-        ));
-    }
 
     if !slurm_cluster.is_empty() {
         cache::set_cluster(&slurm_cluster).await?;
     }
 
-    // connect the single shared Slurm client - this will be used in the
-    // async function (we can't bind variables to async functions, or else
-    // we would just pass the client with the environment)
-    slurm::connect(&slurm_server, &slurm_user, &token_command, token_lifespan).await?;
+    let slurm_server = config.option("slurm-server", "");
 
-    tracing::info!("Connected to slurm server at {}", slurm_server);
+    if slurm_server.is_empty() {
+        // we are using sacctmgr and the commandline to interact
+        // with slurm, because slurmrestd is not available
+        async_runnable! {
+            ///
+            /// Runnable function that will be called when a job is received
+            /// by the agent
+            ///
+            pub async fn sacctmgr_runner(envelope: Envelope) -> Result<Job, templemeads::Error>
+            {
+                let job = envelope.job();
 
-    async_runnable! {
-        ///
-        /// Runnable function that will be called when a job is received
-        /// by the agent
-        ///
-        pub async fn slurm_runner(envelope: Envelope) -> Result<Job, templemeads::Error>
-        {
-            let job = envelope.job();
-
-            match job.instruction() {
-                AddLocalUser(user) => {
-                    slurm::add_user(&user).await?;
-                    let job = job.completed("Success!")?;
-                    Ok(job)
-                },
-                RemoveLocalUser(mapping) => {
-                    Err(Error::IncompleteCode(
-                        format!("RemoveLocalUser instruction not implemented yet - cannot remove {}", mapping),
-                    ))
-                },
-                _ => {
-                    Err(Error::InvalidInstruction(
-                        format!("Invalid instruction: {}. Slurm only supports add_local_user and remove_local_user", job.instruction()),
-                    ))
+                match job.instruction() {
+                    AddLocalUser(user) => {
+                        sacctmgr::add_user(&user).await?;
+                        let job = job.completed("Success!")?;
+                        Ok(job)
+                    },
+                    RemoveLocalUser(mapping) => {
+                        Err(Error::IncompleteCode(
+                            format!("RemoveLocalUser instruction not implemented yet - cannot remove {}", mapping),
+                        ))
+                    },
+                    _ => {
+                        Err(Error::InvalidInstruction(
+                            format!("Invalid instruction: {}. Slurm only supports add_local_user and remove_local_user", job.instruction()),
+                        ))
+                    }
                 }
             }
         }
-    }
 
-    run(config, slurm_runner).await?;
+        run(config, sacctmgr_runner).await?;
+    } else {
+        // we will use slurmrestd to interact with slurm
+        let slurm_user = config.option("slurm-user", "");
+        let token_command = config.option("token-command", "");
+        let token_lifespan = config.option("token-lifespan", "1800");
+
+        let mut token_lifespan: u32 = match token_lifespan.parse() {
+            Ok(lifespan) => lifespan,
+            Err(_) => {
+                return Err(anyhow::anyhow!(
+                    "Invalid token lifespan provided. This should be a number of seconds."
+                        .to_owned(),
+                ));
+            }
+        };
+
+        if token_lifespan < 10 {
+            tracing::warn!("Cannot set the token lifespan to less than 10 seconds.");
+            tracing::warn!("Setting it to a minimum of 10 seconds...");
+            token_lifespan = 10;
+        }
+
+        if token_command.is_empty() {
+            return Err(anyhow::anyhow!(
+                "No token command provided. This should be the command needed to \
+             generate a valid JWT token. Set this in the token-command \
+             option."
+                    .to_owned(),
+            ));
+        }
+
+        // connect the single shared Slurm client - this will be used in the
+        // async function (we can't bind variables to async functions, or else
+        // we would just pass the client with the environment)
+        slurm::connect(&slurm_server, &slurm_user, &token_command, token_lifespan).await?;
+
+        tracing::info!("Connected to slurm server at {}", slurm_server);
+
+        async_runnable! {
+            ///
+            /// Runnable function that will be called when a job is received
+            /// by the agent
+            ///
+            pub async fn slurm_runner(envelope: Envelope) -> Result<Job, templemeads::Error>
+            {
+                let job = envelope.job();
+
+                match job.instruction() {
+                    AddLocalUser(user) => {
+                        slurm::add_user(&user).await?;
+                        let job = job.completed("Success!")?;
+                        Ok(job)
+                    },
+                    RemoveLocalUser(mapping) => {
+                        Err(Error::IncompleteCode(
+                            format!("RemoveLocalUser instruction not implemented yet - cannot remove {}", mapping),
+                        ))
+                    },
+                    _ => {
+                        Err(Error::InvalidInstruction(
+                            format!("Invalid instruction: {}. Slurm only supports add_local_user and remove_local_user", job.instruction()),
+                        ))
+                    }
+                }
+            }
+        }
+
+        run(config, slurm_runner).await?;
+    }
 
     Ok(())
 }

--- a/slurm/src/slurm.rs
+++ b/slurm/src/slurm.rs
@@ -747,7 +747,7 @@ async fn login(
     };
 
     // now get the requested cluster from the cache
-    let requested_cluster = cache::get_cluster().await?;
+    let requested_cluster = cache::get_option_cluster().await?;
 
     if let Some(requested_cluster) = requested_cluster {
         if clusters.contains(&requested_cluster) {
@@ -1109,7 +1109,7 @@ async fn add_account_association(account: &SlurmAccount) -> Result<(), Error> {
     }
 
     // get the cluster name from the cache
-    let cluster = cache::get_cluster().await?.unwrap_or("linux".to_string());
+    let cluster = cache::get_cluster().await?;
 
     // add the association condition to the account
     let payload = serde_json::json!({

--- a/slurm/src/slurm.rs
+++ b/slurm/src/slurm.rs
@@ -1359,23 +1359,6 @@ impl SlurmAccount {
         })
     }
 
-    pub fn from_sacctmgr(line: &str) -> Result<Self, Error> {
-        let parts: Vec<&str> = line.split('|').collect();
-
-        if parts.len() < 2 {
-            return Err(Error::Call(format!(
-                "Could not parse sacctmgr line: {}",
-                line
-            )));
-        }
-
-        Ok(SlurmAccount {
-            name: clean_account_name(parts[0])?,
-            description: parts[1].to_string(),
-            organization: parts[2].to_string(),
-        })
-    }
-
     pub fn construct(result: &serde_json::Value) -> Result<Self, Error> {
         let name = match result.get("name") {
             Some(name) => name,

--- a/slurm/src/slurm.rs
+++ b/slurm/src/slurm.rs
@@ -1328,11 +1328,19 @@ pub fn clean_user_name(user: &str) -> Result<String, Error> {
         .to_ascii_lowercase())
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SlurmAccount {
     name: String,
     description: String,
     organization: String,
+}
+
+impl PartialEq for SlurmAccount {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.organization == other.organization
+            && self.description.to_ascii_lowercase() == other.description.to_ascii_lowercase()
+    }
 }
 
 impl Display for SlurmAccount {

--- a/templemeads/src/error.rs
+++ b/templemeads/src/error.rs
@@ -89,6 +89,9 @@ pub enum Error {
 
     #[error("{0}")]
     UnmanagedUser(String),
+
+    #[error("{0}")]
+    UnmanagedGroup(String),
 }
 
 // implement into a paddington::Error


### PR DESCRIPTION
### Added

- Added a command line support for the slurm agent, so that it can use
  `sacctmgr` to create accounts on slurm in addition to the REST API.
  You choose the command line option by not setting the `slurm-server`
  value in the config file.