### PR TITLE
Feature instance groups

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  linux:
+  x86_64:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -42,13 +42,13 @@ jobs:
           name: wheels-linux-${{ matrix.platform.target }}
           path: python/dist
 
-  musllinux:
+  aarch64:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
         platform:
           - runner: ubuntu-latest
-            target: x86_64
+            target: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -60,19 +60,19 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
-          manylinux: musllinux_1_2
+          manylinux: auto
           working-directory: python
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.target }}
           path: python/dist
 
   release:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, musllinux]
+    needs: [x86_64, aarch64]
     permissions:
       # Use to sign the release artifacts
       id-token: write

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,37 +42,11 @@ jobs:
           name: wheels-linux-${{ matrix.platform.target }}
           path: python/dist
 
-  aarch64:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-latest
-            target: aarch64
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: 'true'
-          manylinux: auto
-          working-directory: python
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: python/dist
-
   release:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [x86_64, aarch64]
+    needs: [x86_64]
     permissions:
       # Use to sign the release artifacts
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added `instance_groups` to the FreeIPA agent, so that is is possible to
+  specify additional groups that a user should be added to when they are
+  added from a specific instance. This is useful when multiple instances
+  share the same freeipa agent, and you want to add them to different groups.
 
 ## [0.1.0] - 2024-11-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.1.0] - 2024-11-26
 ### Added
 - Added full recovery support, so that agents can restore their boards
   after they restart. Also added a queue, so that messages are queued
@@ -12,14 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   time is given for an agent to first connect and identify itself. All of
   this makes the system more robust and reliable, as most jobs are now
   tolerant of individual agents going down.
-
 - Added a better handshake so that agents communicate both their comms
   engine details (e.g. paddington version 0.0.25) and their agent
   engine details (e.g. templemeads version 0.0.25). This will future proof
   us if we make any future changes to the protocols. Note that this
   is BREAKING, so agents cannot commnunicate with older versions of
   openportal
-
 - Added an expiry to jobs, default to 1 minute, that means that both
   jobs are now cleaned automatically from boards once expired (by a
   quiet background tokio task), and that putter of jobs can get a signal
@@ -31,17 +31,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   set the bridge agent to put jobs with a expiry of 60 minutes, so that
   there is plenty of time for the web portal to fetch the results without
   worrying about them being expired.
-
 - Added a command line support for the slurm agent, so that it can use
   `sacctmgr` to create accounts on slurm in addition to the REST API.
   You choose the command line option by not setting the `slurm-server`
   value in the config file.
 
 ### Fixed
-
 - General bug fixes and cleaning of output logging to improve resilience
   and make it easier to debug issues.
-
 
 ## [0.0.25] - 2024-11-20
 ### Fixed
@@ -183,6 +180,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Initial release
   This is an initial alpha release of the OpenPortal project. It is not yet feature complete and is not recommended for production use.
 
+[0.1.0]: https://github.com/isambard-sc/openportal/releases/tag/0.1.0
 [0.0.25]: https://github.com/isambard-sc/openportal/releases/tag/0.0.25
 [0.0.24]: https://github.com/isambard-sc/openportal/releases/tag/0.0.24
 [0.0.23]: https://github.com/isambard-sc/openportal/releases/tag/0.0.23

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "op-bridge"
-version = "0.0.25"
+version = "0.1.0"
 description = "An example of an OpenPortal user portal to OpenPortal bridge"
 edition = "2021"
 license = "MIT"

--- a/cluster/Cargo.toml
+++ b/cluster/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "op-cluster"
-version = "0.0.25"
+version = "0.1.0"
 description = "An example of an OpenPortal cluster instance agent"
 edition = "2021"
 license = "MIT"

--- a/clusters/Cargo.toml
+++ b/clusters/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "op-clusters"
-version = "0.0.25"
+version = "0.1.0"
 description = "An example of an OpenPortal cluster platform agent"
 edition = "2021"
 license = "MIT"

--- a/docs/cmdline/cluster/Cargo.toml
+++ b/docs/cmdline/cluster/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "example-cluster"
-version = "0.0.25"
+version = "0.1.0"
 description = "templemeads command line example - cluster agent"
 edition = "2021"
 license = "MIT"

--- a/docs/cmdline/portal/Cargo.toml
+++ b/docs/cmdline/portal/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "example-portal"
-version = "0.0.25"
+version = "0.1.0"
 description = "templemeads command line example - portal agent"
 edition = "2021"
 license = "MIT"

--- a/docs/echo/Cargo.toml
+++ b/docs/echo/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "example-echo"
-version = "0.0.25"
+version = "0.1.0"
 description = "Paddington Echo Service example"
 edition = "2021"
 license = "MIT"

--- a/docs/job/Cargo.toml
+++ b/docs/job/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "example-job"
-version = "0.0.25"
+version = "0.1.0"
 description = "templemeads job example"
 edition = "2021"
 license = "MIT"

--- a/filesystem/Cargo.toml
+++ b/filesystem/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "op-filesystem"
-version = "0.0.25"
+version = "0.1.0"
 description = "Agent that interfaces OpenPortal with a filesystem"
 edition = "2021"
 license = "MIT"

--- a/freeipa/Cargo.toml
+++ b/freeipa/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "op-freeipa"
-version = "0.0.25"
+version = "0.1.0"
 description = "Agent that interfaces OpenPortal with FreeIPA"
 edition = "2021"
 license = "MIT"

--- a/freeipa/src/freeipa.rs
+++ b/freeipa/src/freeipa.rs
@@ -14,6 +14,8 @@ use templemeads::grammar::{UserIdentifier, UserMapping};
 use templemeads::Error;
 use tokio::sync::{Mutex, MutexGuard};
 
+use templemeads::agent::Peer;
+
 use crate::cache;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -488,6 +490,16 @@ impl std::fmt::Display for IPAGroup {
 impl IPAGroup {
     fn new(groupid: &str, description: &str) -> Result<Self, Error> {
         // check that the groupid is valid .... PARSING RULES
+        let groupid = groupid.trim();
+        let description = description.trim();
+
+        if groupid.is_empty() {
+            return Err(Error::Parse("Group identifier is empty".to_string()));
+        }
+
+        if description.is_empty() {
+            return Err(Error::Parse("Group description is empty".to_string()));
+        }
 
         Ok(IPAGroup {
             groupid: groupid.to_string(),
@@ -531,7 +543,7 @@ impl IPAGroup {
         Ok(groups)
     }
 
-    pub fn parse(groups: &str) -> Result<Vec<IPAGroup>, Error> {
+    pub fn parse_system_groups(groups: &str) -> Result<Vec<IPAGroup>, Error> {
         let mut g = Vec::new();
         let mut errors = Vec::new();
 
@@ -539,7 +551,70 @@ impl IPAGroup {
             if !group.is_empty() {
                 match IPAGroup::new(group, "OpenPortal-managed group") {
                     Ok(group) => g.push(group),
-                    Err(_) => errors.push(group),
+                    Err(e) => {
+                        tracing::error!("Could not parse group: {}. Error: {}", group, e);
+                        errors.push(group)
+                    }
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(Error::Parse(format!(
+                "Could not parse groups: {:?}",
+                errors.join(",")
+            )));
+        }
+
+        Ok(g)
+    }
+
+    pub fn parse_instance_groups(groups: &str) -> Result<HashMap<Peer, Vec<IPAGroup>>, Error> {
+        let mut g: HashMap<Peer, Vec<IPAGroup>> = HashMap::new();
+        let mut errors = Vec::new();
+
+        for group in groups.split(',') {
+            let parts: Vec<&str> = group.split(':').collect();
+
+            if parts.len() != 2 {
+                errors.push(group);
+                continue;
+            }
+
+            let instance = parts[0].trim();
+
+            if instance.is_empty() {
+                errors.push(group);
+                continue;
+            }
+
+            let peer = match Peer::parse(instance) {
+                Ok(peer) => peer,
+                Err(e) => {
+                    tracing::error!("Could not parse instance: {}. Error: {}", instance, e);
+                    errors.push(group);
+                    continue;
+                }
+            };
+
+            let group = parts[1].trim();
+
+            if group.is_empty() {
+                errors.push(group);
+                continue;
+            }
+
+            match IPAGroup::new(group, "OpenPortal-managed group") {
+                Ok(group) => {
+                    if let Some(groups) = g.get_mut(&peer) {
+                        groups.push(group);
+                    } else {
+                        g.insert(peer.clone(), vec![group]);
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Could not parse group: {}. Error: {}", group, e);
+                    errors.push(group)
                 }
             }
         }
@@ -753,10 +828,13 @@ fn get_primary_group(user: &UserIdentifier) -> String {
 /// or removes them as necessary. Groups will match the project group,
 /// the system groups, and the openportal group.
 ///
-async fn sync_groups(user: &IPAUser) -> Result<IPAUser, Error> {
+async fn sync_groups(user: &IPAUser, instance: &Peer) -> Result<IPAUser, Error> {
     // the user probably doesn't exist, so add them, making sure they
     // are in the correct groups
     let mut groups = cache::get_system_groups().await?;
+
+    // add in the groups for this instance
+    groups.extend(cache::get_instance_groups(instance).await?);
 
     // add in the "openportal" group, to which all users managed by
     // OpenPortal must belong
@@ -872,11 +950,11 @@ async fn sync_groups(user: &IPAUser) -> Result<IPAUser, Error> {
     }
 }
 
-pub async fn add_user(user: &UserIdentifier) -> Result<IPAUser, Error> {
+pub async fn add_user(user: &UserIdentifier, instance: &Peer) -> Result<IPAUser, Error> {
     // return the user if they already exist
     if let Some(user) = get_user(user).await? {
         // make sure that the groups are correct
-        match sync_groups(&user).await {
+        match sync_groups(&user, instance).await {
             Ok(user) => {
                 tracing::info!("Added user [cached] {}", user);
                 return Ok(user);
@@ -982,7 +1060,7 @@ pub async fn add_user(user: &UserIdentifier) -> Result<IPAUser, Error> {
 
     // now synchronise the groups - this won't do anything if another
     // thread has already beaten us to creating the user
-    match sync_groups(&user).await {
+    match sync_groups(&user, instance).await {
         Ok(user) => {
             tracing::info!("Added user: {}", user);
             Ok(user)

--- a/freeipa/src/freeipa.rs
+++ b/freeipa/src/freeipa.rs
@@ -544,6 +544,12 @@ impl IPAGroup {
     }
 
     pub fn parse_system_groups(groups: &str) -> Result<Vec<IPAGroup>, Error> {
+        let groups = groups.trim();
+
+        if groups.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let mut g = Vec::new();
         let mut errors = Vec::new();
 
@@ -570,6 +576,12 @@ impl IPAGroup {
     }
 
     pub fn parse_instance_groups(groups: &str) -> Result<HashMap<Peer, Vec<IPAGroup>>, Error> {
+        let groups = groups.trim();
+
+        if groups.is_empty() {
+            return Ok(HashMap::new());
+        }
+
         let mut g: HashMap<Peer, Vec<IPAGroup>> = HashMap::new();
         let mut errors = Vec::new();
 

--- a/paddington/Cargo.toml
+++ b/paddington/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "paddington"
-version = "0.0.25"
+version = "0.1.0"
 description = "A library for implementing the OpenPortal communication protocol"
 edition = "2021"
 license = "MIT"

--- a/portal/Cargo.toml
+++ b/portal/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "op-portal"
-version = "0.0.25"
+version = "0.1.0"
 description = "An example of an OpenPortal portal interface service"
 edition = "2021"
 license = "MIT"

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "op-provider"
-version = "0.0.25"
+version = "0.1.0"
 description = "An example of an OpenPortal provider interface service"
 edition = "2021"
 license = "MIT"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "openportal"
-version = "0.0.25"
+version = "0.1.0"
 description = "Python wrappers for OpenPortal"
 edition = "2021"
 license = "MIT"

--- a/slurm/Cargo.toml
+++ b/slurm/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "op-slurm"
-version = "0.0.25"
+version = "0.1.0"
 description = "Agent that interfaces OpenPortal with the slurm scheduler"
 edition = "2021"
 license = "MIT"

--- a/templemeads/Cargo.toml
+++ b/templemeads/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "templemeads"
-version = "0.0.25"
+version = "0.1.0"
 description = "A library for interfacing OpenPortal with specific portals"
 edition = "2021"
 license = "MIT"

--- a/templemeads/src/agent.rs
+++ b/templemeads/src/agent.rs
@@ -108,6 +108,26 @@ impl Peer {
         }
     }
 
+    pub fn parse(name: &str) -> Result<Self, Error> {
+        let parts: Vec<&str> = name.split('@').collect();
+
+        if parts.len() != 2 {
+            return Err(Error::InvalidPeer(name.to_string()));
+        }
+
+        let peer_name = parts[0].trim();
+        let peer_zone = parts[1].trim();
+
+        if peer_name.is_empty() || peer_zone.is_empty() {
+            return Err(Error::InvalidPeer(name.to_string()));
+        }
+
+        Ok(Self {
+            name: peer_name.to_string(),
+            zone: peer_zone.to_string(),
+        })
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/templemeads/src/error.rs
+++ b/templemeads/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
     InvalidInstruction(String),
 
     #[error("{0}")]
+    InvalidPeer(String),
+
+    #[error("{0}")]
     InvalidState(String),
 
     #[error("{0}")]


### PR DESCRIPTION
### Added
- Added `instance_groups` to the FreeIPA agent, so that is is possible to
  specify additional groups that a user should be added to when they are
  added from a specific instance. This is useful when multiple instances
  share the same freeipa agent, and you want to add them to different groups.