### PR TITLE
Feature waldur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added automatic building of Python Linux aarch64 binaries, so that
   the Python module can be used on ARM64 systems.
 
+- Cleaned up the Python API and added in lots of convenience functions.
+  Objects are now correctly returned from the `run` function, so that you
+  don't need to parse anything. Also added in the ability to default
+  wait for a command to run
+
+- Added in extra commands to add and remove projects, list users in a
+  project, and list projects in a portal. Some of these are still stubbed.
+
+- Added in `ProjectIdentifier` and `ProjectMapping` to mirror the
+  equivalent `User` classes. Also cleaned up the concept of local
+  users and groups, so that a `UserMapping` maps a user to a local
+  unix username and unix group, while the `ProjectMapping` maps a
+  project to a local unix group.
 
 ## [0.1.1] - 2024-12-02
 ### Added

--- a/cluster/src/main.rs
+++ b/cluster/src/main.rs
@@ -7,8 +7,10 @@ use templemeads::agent;
 use templemeads::agent::instance::{process_args, run, Defaults};
 use templemeads::agent::Type as AgentType;
 use templemeads::async_runnable;
-use templemeads::grammar::Instruction::{AddUser, RemoveUser};
-use templemeads::grammar::{UserIdentifier, UserMapping};
+use templemeads::grammar::Instruction::{
+    AddProject, AddUser, GetProjects, GetUsers, RemoveProject, RemoveUser,
+};
+use templemeads::grammar::{ProjectIdentifier, ProjectMapping, UserIdentifier, UserMapping};
 use templemeads::job::{Envelope, Job};
 use templemeads::Error;
 
@@ -68,6 +70,40 @@ async fn main() -> Result<()> {
             let mut job = envelope.job();
 
             match job.instruction() {
+                GetProjects() => {
+                    // get the list of projects from the cluster
+                    tracing::info!("Getting list of projects");
+                    job = job.completed("Projects retrieved")?;
+                },
+                GetUsers(project) => {
+                    // get the list of users from the cluster
+                    tracing::info!("Getting list of users in project {}", project);
+                    job = job.completed("Users retrieved")?;
+                },
+                AddProject(project) => {
+                    // add the project to the cluster
+                    tracing::info!("Adding project to cluster: {}", project);
+                    let mapping = create_project(me.name(), &project).await?;
+
+                    job = job.running(Some("Step 1/3: Project created".to_string()))?;
+                    job = job.update(&sender).await?;
+
+                    // now create the project directories
+                    create_project_directories(me.name(), &mapping).await?;
+
+                    job = job.running(Some("Step 2/3: Directories created".to_string()))?;
+                    job = job.update(&sender).await?;
+
+                    // and finally add the project to the job scheduler
+                    add_project_to_scheduler(me.name(), &project, &mapping).await?;
+
+                    job = job.completed(mapping)?;
+                },
+                RemoveProject(project) => {
+                    // remove the project from the cluster
+                    tracing::info!("Removing project from cluster: {}", project);
+                    job = job.completed("Project removed")?;
+                },
                 AddUser(user) => {
                     // add the user to the cluster
                     tracing::info!("Adding user to cluster: {}", user);
@@ -77,7 +113,7 @@ async fn main() -> Result<()> {
                     job = job.update(&sender).await?;
 
                     // now create their home directories
-                    let homedir = create_directories(me.name(), &mapping).await?;
+                    let homedir = create_user_directories(me.name(), &mapping).await?;
 
                     job = job.running(Some("Step 2/3: Directories created".to_string()))?;
                     job = job.update(&sender).await?;
@@ -86,7 +122,7 @@ async fn main() -> Result<()> {
                     update_homedir(me.name(), &user, &homedir).await?;
 
                     // and finally add the user to the job scheduler
-                    add_to_scheduler(me.name(), &user, &mapping).await?;
+                    add_user_to_scheduler(me.name(), &user, &mapping).await?;
 
                     job = job.completed(mapping)?;
                 }
@@ -111,6 +147,43 @@ async fn main() -> Result<()> {
     run(config, cluster_runner).await?;
 
     Ok(())
+}
+
+async fn create_project(me: &str, project: &ProjectIdentifier) -> Result<ProjectMapping, Error> {
+    // find the Account agent
+    match agent::account(30).await {
+        Some(account) => {
+            // send the add_job to the account agent
+            let job = Job::parse(
+                &format!("{}.{} add_project {}", me, account.name(), project),
+                false,
+            )?
+            .put(&account)
+            .await?;
+
+            // Wait for the add_job to complete
+            let result = job.wait().await?.result::<ProjectMapping>()?;
+
+            match result {
+                Some(mapping) => {
+                    tracing::info!("Project added to account agent: {:?}", mapping);
+                    Ok(mapping)
+                }
+                None => {
+                    tracing::error!("Error creating the project group: {:?}", job);
+                    Err(Error::Call(
+                        format!("Error creating the project group: {:?}", job).to_string(),
+                    ))
+                }
+            }
+        }
+        None => {
+            tracing::error!("No account agent found");
+            Err(Error::MissingAgent(
+                "Cannot run the job because there is no account agent".to_string(),
+            ))
+        }
+    }
 }
 
 async fn create_account(me: &str, user: &UserIdentifier) -> Result<UserMapping, Error> {
@@ -150,7 +223,44 @@ async fn create_account(me: &str, user: &UserIdentifier) -> Result<UserMapping, 
     }
 }
 
-async fn create_directories(me: &str, mapping: &UserMapping) -> Result<String, Error> {
+async fn create_project_directories(me: &str, mapping: &ProjectMapping) -> Result<String, Error> {
+    // find the Filesystem agent
+    match agent::filesystem(30).await {
+        Some(filesystem) => {
+            // send the add_job to the filesystem agent
+            let job = Job::parse(
+                &format!("{}.{} add_local_project {}", me, filesystem.name(), mapping),
+                false,
+            )?
+            .put(&filesystem)
+            .await?;
+
+            // Wait for the add_job to complete
+            let result = job.wait().await?.result::<String>()?;
+
+            match result {
+                Some(homedir) => {
+                    tracing::info!("Directories created for project: {:?}", mapping);
+                    Ok(homedir)
+                }
+                None => {
+                    tracing::error!("Error creating the project directories: {:?}", job);
+                    Err(Error::Call(
+                        format!("Error creating the project directories: {:?}", job).to_string(),
+                    ))
+                }
+            }
+        }
+        None => {
+            tracing::error!("No filesystem agent found");
+            Err(Error::MissingAgent(
+                "Cannot run the job because there is no filesystem agent".to_string(),
+            ))
+        }
+    }
+}
+
+async fn create_user_directories(me: &str, mapping: &UserMapping) -> Result<String, Error> {
     // find the Filesystem agent
     match agent::filesystem(30).await {
         Some(filesystem) => {
@@ -230,7 +340,49 @@ async fn update_homedir(me: &str, user: &UserIdentifier, homedir: &str) -> Resul
     }
 }
 
-async fn add_to_scheduler(
+async fn add_project_to_scheduler(
+    me: &str,
+    project: &ProjectIdentifier,
+    mapping: &ProjectMapping,
+) -> Result<(), Error> {
+    // find the Scheduler agent
+    match agent::scheduler(30).await {
+        Some(scheduler) => {
+            // send the add_job to the scheduler agent
+            let job = Job::parse(
+                &format!("{}.{} add_local_project {}", me, scheduler.name(), mapping),
+                false,
+            )?
+            .put(&scheduler)
+            .await?;
+
+            // Wait for the add_job to complete
+            let result = job.wait().await?.result::<String>()?;
+
+            match result {
+                Some(_) => {
+                    tracing::info!("Project {} added to scheduler", project);
+                    Ok(())
+                }
+                None => {
+                    tracing::error!("Error adding the project to the scheduler: {:?}", project);
+                    Err(Error::Call(
+                        format!("Error adding the project to the scheduler: {:?}", project)
+                            .to_string(),
+                    ))
+                }
+            }
+        }
+        None => {
+            tracing::error!("No scheduler agent found");
+            Err(Error::MissingAgent(
+                "Cannot run the job because there is no scheduler agent".to_string(),
+            ))
+        }
+    }
+}
+
+async fn add_user_to_scheduler(
     me: &str,
     user: &UserIdentifier,
     mapping: &UserMapping,

--- a/cluster/src/main.rs
+++ b/cluster/src/main.rs
@@ -73,12 +73,12 @@ async fn main() -> Result<()> {
                 GetProjects() => {
                     // get the list of projects from the cluster
                     tracing::info!("Getting list of projects");
-                    job = job.completed("Projects retrieved")?;
+                    job = job.completed("Projects retrieved".to_string())?;
                 },
                 GetUsers(project) => {
                     // get the list of users from the cluster
                     tracing::info!("Getting list of users in project {}", project);
-                    job = job.completed("Users retrieved")?;
+                    job = job.completed("Users retrieved".to_string())?;
                 },
                 AddProject(project) => {
                     // add the project to the cluster
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
                 RemoveProject(project) => {
                     // remove the project from the cluster
                     tracing::info!("Removing project from cluster: {}", project);
-                    job = job.completed("Project removed")?;
+                    job = job.completed("Project removed".to_string())?;
                 },
                 AddUser(user) => {
                     // add the user to the cluster
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
                 RemoveUser(user) => {
                     // remove the user from the cluster
                     tracing::info!("Removing user from cluster: {}", user);
-                    job = job.completed("User removed")?;
+                    job = job.completed("User removed".to_string())?;
                 }
                 _ => {
                     tracing::error!("Unknown instruction: {:?}", job.instruction());

--- a/docs/cmdline/cluster/src/main.rs
+++ b/docs/cmdline/cluster/src/main.rs
@@ -60,7 +60,7 @@ async_runnable! {
 
                 tracing::info!("Here we would implement the business logic to add the user to the cluster");
 
-                job = job.completed("account created")?;
+                job = job.completed("account created".to_string())?;
             }
             RemoveUser(user) => {
                 // remove the user from the cluster
@@ -72,7 +72,7 @@ async_runnable! {
                     job = job.errored(&format!("You are not allowed to remove the account for {:?}",
                                       user.username()))?;
                 } else {
-                    job = job.completed("account removed")?;
+                    job = job.completed("account removed".to_string())?;
                 }
             }
             _ => {

--- a/docs/job/src/main.rs
+++ b/docs/job/src/main.rs
@@ -161,7 +161,7 @@ async_runnable! {
 
                 tracing::info!("Here we would implement the business logic to add the user to the cluster");
 
-                job = job.completed("account created")?;
+                job = job.completed("account created".to_string())?;
             }
             RemoveUser(user) => {
                 // remove the user from the cluster
@@ -173,7 +173,7 @@ async_runnable! {
                     job = job.errored(&format!("You are not allowed to remove the account for {:?}",
                                       user.username()))?;
                 } else {
-                    job = job.completed("account removed")?;
+                    job = job.completed("account removed".to_string())?;
                 }
             }
             _ => {

--- a/filesystem/src/main.rs
+++ b/filesystem/src/main.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<()> {
                     let home_permissions = cache::get_home_permissions().await?;
 
                     filesystem::create_home_dir(&home_dir, mapping.local_user(),
-                                                mapping.local_project(),
+                                                mapping.local_group(),
                                                 &home_permissions).await?;
 
                     // update the job with the user's home directory
@@ -158,8 +158,8 @@ async fn create_project_dirs_and_links(mapping: &ProjectMapping) -> Result<Strin
     // Eventually we would need to encode the portal into this...
     let project_dir_name = mapping.project().project();
 
-    // The group name for any project dirs are the mapping local project IDs
-    let group_name = mapping.local_project();
+    // The group name for any project dirs are the mapping local group IDs
+    let group_name = mapping.local_group();
 
     // home directory is, e.g. /home/project/user
     let home_root = format!("{}/{}", cache::get_home_root().await?, project_dir_name);

--- a/filesystem/src/main.rs
+++ b/filesystem/src/main.rs
@@ -6,7 +6,10 @@ use anyhow::Result;
 use templemeads::agent::filesystem::{process_args, run, Defaults};
 use templemeads::agent::Type as AgentType;
 use templemeads::async_runnable;
-use templemeads::grammar::Instruction::{AddLocalUser, RemoveLocalUser};
+use templemeads::grammar::Instruction::{
+    AddLocalProject, AddLocalUser, RemoveLocalProject, RemoveLocalUser,
+};
+use templemeads::grammar::ProjectMapping;
 use templemeads::job::{Envelope, Job};
 use templemeads::Error;
 
@@ -96,51 +99,31 @@ async fn main() -> Result<()> {
             let job = envelope.job();
 
             match job.instruction() {
+                AddLocalProject(mapping) => {
+                    let home_root = create_project_dirs_and_links(&mapping).await?;
+
+                    // update the job with the main project home directory root
+                    let job = job.completed(home_root)?;
+
+                    Ok(job)
+                },
+                RemoveLocalProject(mapping) => {
+                    Err(Error::IncompleteCode(
+                        format!("RemoveLocalProject instruction not implemented yet - cannot remove {}", mapping),
+                    ))
+                },
                 AddLocalUser(mapping) => {
-                    // home directory is, e.g. /home/project/user
-                    let home_root = format!("{}/{}", cache::get_home_root().await?, mapping.user().project());
+                    // make sure all project dirs are created, and get back the
+                    // project home root
+                    let home_root = create_project_dirs_and_links(&mapping.clone().into()).await?;
+
+                    // create the home directory is, e.g. /home_root/user
                     let home_dir = format!("{}/{}", home_root, mapping.local_user());
                     let home_permissions = cache::get_home_permissions().await?;
-
-                    let project_dirs = cache::get_project_roots().await?;
-                    let project_permissions = cache::get_project_permissions().await?;
-                    let project_links = cache::get_project_links().await?;
-
-                    if project_dirs.len() != project_permissions.len() {
-                        return Err(Error::Misconfigured(
-                            "Number of project directories does not match number of permissions".to_owned(),
-                        ));
-                    }
-
-                    if project_dirs.len() != project_links.len() {
-                        return Err(Error::Misconfigured(
-                            "Number of project directories does not match number of links".to_owned(),
-                        ));
-                    }
-
-                    // create the root in which the user's home directory will be created - this is /{home_root}/{project}
-                    filesystem::create_project_dir(&home_root, mapping.local_project(),
-                                                   "0755").await?;
 
                     filesystem::create_home_dir(&home_dir, mapping.local_user(),
                                                 mapping.local_project(),
                                                 &home_permissions).await?;
-
-
-                    // create the project directories
-                    for i in 0..project_dirs.len() {
-                        let project_dir = format!("{}/{}", project_dirs[i], mapping.user().project());
-                        filesystem::create_project_dir(&project_dir, mapping.local_project(),
-                                                       &project_permissions[i]).await?;
-                    }
-
-                    // now create any necessary project links
-                    for i in 0..project_links.len() {
-                        if let Some(link) = project_links[i].as_ref() {
-                            filesystem::create_project_link(&format!("{}/{}", project_dirs[i], mapping.user().project()),
-                                                            link, &mapping.user().project()).await?;
-                        }
-                    }
 
                     // update the job with the user's home directory
                     let job = job.completed(home_dir)?;
@@ -164,4 +147,60 @@ async fn main() -> Result<()> {
     run(config, filesystem_runner).await?;
 
     Ok(())
+}
+
+///
+/// Create the project directories and links for a given ProjectMapping,
+/// returning the home root directory for the project
+///
+async fn create_project_dirs_and_links(mapping: &ProjectMapping) -> Result<String, Error> {
+    // The name of the project directory comes from the project part of the ProjectIdentifier
+    // Eventually we would need to encode the portal into this...
+    let project_dir_name = mapping.project().project();
+
+    // The group name for any project dirs are the mapping local project IDs
+    let group_name = mapping.local_project();
+
+    // home directory is, e.g. /home/project/user
+    let home_root = format!("{}/{}", cache::get_home_root().await?, project_dir_name);
+
+    let project_dirs = cache::get_project_roots().await?;
+    let project_permissions = cache::get_project_permissions().await?;
+    let project_links = cache::get_project_links().await?;
+
+    if project_dirs.len() != project_permissions.len() {
+        return Err(Error::Misconfigured(
+            "Number of project directories does not match number of permissions".to_owned(),
+        ));
+    }
+
+    if project_dirs.len() != project_links.len() {
+        return Err(Error::Misconfigured(
+            "Number of project directories does not match number of links".to_owned(),
+        ));
+    }
+
+    // create the root in which the user's home directory will be created - this is /{home_root}/{project}
+    filesystem::create_project_dir(&home_root, group_name, "0755").await?;
+
+    // create the project directories
+    for i in 0..project_dirs.len() {
+        let project_dir = format!("{}/{}", project_dirs[i], project_dir_name);
+        filesystem::create_project_dir(&project_dir, group_name, &project_permissions[i]).await?;
+    }
+
+    // now create any necessary project links
+    for i in 0..project_links.len() {
+        if let Some(link) = project_links[i].as_ref() {
+            filesystem::create_project_link(
+                &format!("{}/{}", project_dirs[i], project_dir_name),
+                link,
+                &project_dir_name,
+            )
+            .await?;
+        }
+    }
+
+    // return the home root
+    Ok(home_root)
 }

--- a/freeipa/src/main.rs
+++ b/freeipa/src/main.rs
@@ -13,7 +13,9 @@ mod cache;
 use templemeads::agent::account::{process_args, run, Defaults};
 use templemeads::agent::{Peer, Type as AgentType};
 use templemeads::async_runnable;
-use templemeads::grammar::Instruction::{AddUser, RemoveUser, UpdateHomeDir};
+use templemeads::grammar::Instruction::{
+    AddProject, AddUser, RemoveProject, RemoveUser, UpdateHomeDir,
+};
 use templemeads::job::{Envelope, Job};
 use templemeads::Error;
 
@@ -102,6 +104,16 @@ async fn main() -> Result<()> {
             let sender = envelope.sender();
 
             match job.instruction() {
+                AddProject(project) => {
+                    let project = freeipa::add_project(&project).await?;
+                    let job = job.completed(project.mapping()?)?;
+                    Ok(job)
+                },
+                RemoveProject(project) => {
+                    Err(Error::IncompleteCode(
+                        format!("RemoveProject instruction not implemented yet - cannot remove {}", project),
+                    ))
+                },
                 AddUser(user) => {
                     let user = freeipa::add_user(&user, &sender).await?;
                     let job = job.completed(user.mapping()?)?;

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { version="1.0.86", features = ["backtrace"] }
 chrono = "0.4.38"
 once_cell = "1.19.0"
 paddington = { path = "../paddington" }
-pyo3 = { version="0.22.2" }
+pyo3 = { version="0.23.0" }
 reqwest = { version = "0.12.7", default-features = false, features = ["cookies", "json", "blocking", "rustls-tls"] }
 secrecy = { version = "0.8.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -2,20 +2,21 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::{Context, Result};
-use chrono::serde::ts_seconds;
 use chrono::Utc;
 use once_cell::sync::Lazy;
 use paddington::SecretKey;
 use pyo3::exceptions::PyOSError;
 use pyo3::prelude::*;
+use pyo3::types::{PyDateTime, PyNone, PyString};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::path;
 use std::sync::RwLock;
-use templemeads::job::Status;
+use templemeads::destination;
+use templemeads::grammar;
+use templemeads::job;
 use templemeads::server::sign_api_call;
 use templemeads::Error;
 use url::Url;
-use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BridgeConfig {
@@ -249,149 +250,80 @@ fn health() -> PyResult<Health> {
 ///
 #[pyclass]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct Job {
-    id: Uuid,
-    #[serde(with = "ts_seconds")]
-    created: chrono::DateTime<Utc>,
-    #[serde(with = "ts_seconds")]
-    changed: chrono::DateTime<Utc>,
-    #[serde(with = "ts_seconds")]
-    expires: chrono::DateTime<Utc>,
-    version: u64,
-    command: String,
-    state: Status,
-    result: Option<String>,
+struct Job(job::Job);
+
+impl From<job::Job> for Job {
+    fn from(job: job::Job) -> Self {
+        Job(job)
+    }
 }
 
 #[pymethods]
 impl Job {
     #[getter]
-    fn id(&self) -> PyResult<String> {
-        Ok(self.id.to_string())
-    }
-
-    fn _is_expired(&self) -> bool {
-        match self.state {
-            Status::Complete => false,
-            Status::Error => false,
-            _ => Utc::now() > self.expires,
-        }
+    fn id(&self) -> PyResult<Uuid> {
+        Ok(self.0.id().into())
     }
 
     #[getter]
-    fn state(&self) -> PyResult<String> {
-        if self._is_expired() {
-            match self.state {
-                Status::Complete => Ok("Complete".to_owned()),
-                _ => Ok("Error".to_owned()),
-            }
-        } else {
-            match self.state {
-                Status::Created => Ok("Created".to_owned()),
-                Status::Pending => Ok("Pending".to_owned()),
-                Status::Running => Ok("Running".to_owned()),
-                Status::Complete => Ok("Complete".to_owned()),
-                Status::Error => Ok("Error".to_owned()),
-            }
-        }
+    fn destination(&self) -> PyResult<Destination> {
+        Ok(self.0.destination().into())
     }
 
     #[getter]
-    fn command(&self) -> PyResult<String> {
-        Ok(self.command.clone())
-    }
-
-    #[getter]
-    fn created(&self) -> PyResult<String> {
-        Ok(self.created.to_rfc3339())
-    }
-
-    #[getter]
-    fn changed(&self) -> PyResult<String> {
-        Ok(self.changed.to_rfc3339())
-    }
-
-    #[getter]
-    fn expires(&self) -> PyResult<String> {
-        Ok(self.expires.to_rfc3339())
-    }
-
-    #[getter]
-    fn result(&self) -> PyResult<Option<String>> {
-        if self.state == Status::Complete {
-            Ok(self.result.clone())
-        } else {
-            Ok(None)
-        }
-    }
-
-    #[getter]
-    fn is_finished(&self) -> PyResult<bool> {
-        Ok(self.state == Status::Complete || self.state == Status::Error || self._is_expired())
+    fn instruction(&self) -> PyResult<Instruction> {
+        Ok(self.0.instruction().into())
     }
 
     #[getter]
     fn is_expired(&self) -> PyResult<bool> {
-        Ok(self._is_expired())
+        Ok(self.0.is_expired())
     }
 
     #[getter]
-    fn is_error(&self) -> PyResult<bool> {
-        match self._is_expired() {
-            true => Ok(self.state != Status::Complete),
-            false => Ok(self.state == Status::Error),
-        }
+    fn is_finished(&self) -> PyResult<bool> {
+        Ok(self.0.is_finished())
     }
 
     #[getter]
-    fn error_message(&self) -> PyResult<Option<String>> {
-        match self._is_expired() {
-            true => {
-                if self.state == Status::Error {
-                    Ok(self.result.clone())
-                } else if self.state == Status::Complete {
-                    Ok(None)
-                } else {
-                    Ok(Some("Job has expired".to_owned()))
-                }
-            }
-            false => {
-                if self.state == Status::Error {
-                    Ok(self.result.clone())
-                } else {
-                    Ok(None)
-                }
-            }
+    fn state(&self) -> PyResult<Status> {
+        Ok(self.0.state().into())
+    }
+
+    #[getter]
+    fn created<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDateTime>> {
+        PyDateTime::from_timestamp(py, self.0.created().timestamp() as f64, None)
+    }
+
+    #[getter]
+    fn changed<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDateTime>> {
+        PyDateTime::from_timestamp(py, self.0.changed().timestamp() as f64, None)
+    }
+
+    #[getter]
+    fn version(&self) -> PyResult<u64> {
+        Ok(self.0.version())
+    }
+
+    #[getter]
+    fn is_error(&self) -> bool {
+        self.0.is_error()
+    }
+
+    #[getter]
+    fn error_message(&self) -> PyResult<String> {
+        match self.0.error_message() {
+            Some(message) => Ok(message.clone()),
+            None => Ok("".to_string()),
         }
     }
 
     #[getter]
     fn progress_message(&self) -> PyResult<String> {
-        match self._is_expired() {
-            true => match self.state {
-                Status::Complete => Ok("Complete".to_owned()),
-                Status::Error => Ok("Error".to_owned()),
-                _ => Ok("Error (expired)".to_owned()),
-            },
-            false => match self.state {
-                Status::Running => {
-                    if let Some(result) = &self.result {
-                        Ok(result.clone())
-                    } else {
-                        Ok("Running".to_owned())
-                    }
-                }
-                Status::Created => Ok("Created".to_owned()),
-                Status::Pending => Ok("Pending".to_owned()),
-                Status::Complete => Ok("Complete".to_owned()),
-                Status::Error => Ok("Error".to_owned()),
-            },
+        match self.0.progress_message() {
+            Some(message) => Ok(message.clone()),
+            None => Ok("".to_string()),
         }
-    }
-
-    #[getter]
-    fn version(&self) -> PyResult<u64> {
-        Ok(self.version)
     }
 
     fn update(&mut self) -> PyResult<()> {
@@ -437,47 +369,317 @@ impl Job {
         self.is_finished()
     }
 
-    fn __str__(&self) -> PyResult<String> {
-        match self._is_expired() {
-            true => match self.state {
-                Status::Complete => Ok(format!(
-                    "Job( command: {}, status: completed, result: {} )",
-                    self.command,
-                    self.result.clone().unwrap_or("None".to_owned())
-                )),
-                Status::Error => Ok(format!(
-                    "Job( command: {}, status: error, message: {} )",
-                    self.command,
-                    self.result.clone().unwrap_or("None".to_owned())
-                )),
-                _ => Ok(format!(
-                    "Job( command: {}, status: error, message: Job has expired )",
-                    self.command
-                )),
-            },
-            false => match self.state {
-                Status::Complete => Ok(format!(
-                    "Job( command: {}, status: completed, result: {} )",
-                    self.command,
-                    self.result.clone().unwrap_or("None".to_owned())
-                )),
-                Status::Error => Ok(format!(
-                    "Job( command: {}, status: error, message: {} )",
-                    self.command,
-                    self.result.clone().unwrap_or("None".to_owned())
-                )),
-                _ => Ok(format!(
-                    "Job( command: {}, status: {:?}, message: {} )",
-                    self.command,
-                    self.state,
-                    self.result.clone().unwrap_or("None".to_owned())
-                )),
-            },
+    #[getter]
+    fn result<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        if !self.is_finished()? {
+            return Err(PyErr::new::<PyOSError, _>("Job is not finished"));
         }
+
+        if self.0.is_error() {
+            return Err(PyErr::new::<PyOSError, _>(self.error_message()?));
+        }
+
+        let result_type = match self.0.result_type() {
+            Ok(result_type) => result_type,
+            Err(e) => return Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
+        };
+
+        match result_type.as_str() {
+            "String" => {
+                let result = match self.0.result::<String>() {
+                    Ok(result) => result,
+                    Err(e) => return Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
+                };
+
+                match result {
+                    Some(result) => Ok(PyString::new(py, &result).into_any()),
+                    None => Ok(PyNone::get(py).as_ref().clone()),
+                }
+            }
+            "None" => Ok(PyNone::get(py).as_ref().clone()),
+            "UserIdentifier" => {
+                let result = match self.0.result::<grammar::UserIdentifier>() {
+                    Ok(result) => result,
+                    Err(e) => return Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
+                };
+
+                match result {
+                    Some(result) => Ok(UserIdentifier::from(result).into_pyobject(py)?.into_any()),
+                    None => Ok(PyNone::get(py).as_ref().clone()),
+                }
+            }
+            "ProjectIdentifier" => {
+                let result = match self.0.result::<grammar::ProjectIdentifier>() {
+                    Ok(result) => result,
+                    Err(e) => return Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
+                };
+
+                match result {
+                    Some(result) => Ok(ProjectIdentifier::from(result)
+                        .into_pyobject(py)?
+                        .into_any()),
+                    None => Ok(PyNone::get(py).as_ref().clone()),
+                }
+            }
+            "UserMapping" => {
+                let result = match self.0.result::<grammar::UserMapping>() {
+                    Ok(result) => result,
+                    Err(e) => return Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
+                };
+
+                match result {
+                    Some(result) => Ok(UserMapping::from(result).into_pyobject(py)?.into_any()),
+                    None => Ok(PyNone::get(py).as_ref().clone()),
+                }
+            }
+            "ProjectMapping" => {
+                let result = match self.0.result::<grammar::ProjectMapping>() {
+                    Ok(result) => result,
+                    Err(e) => return Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
+                };
+
+                match result {
+                    Some(result) => Ok(ProjectMapping::from(result).into_pyobject(py)?.into_any()),
+                    None => Ok(PyNone::get(py).as_ref().clone()),
+                }
+            }
+            _ => Err(PyErr::new::<PyOSError, _>(format!(
+                "Unknown result type: {}",
+                result_type
+            ))),
+        }
+    }
+}
+
+///
+/// Wrappers for the publicly exposed data types
+///
+
+#[pyclass]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Destination(destination::Destination);
+
+#[pymethods]
+impl Destination {
+    #[getter]
+    fn agents(&self) -> PyResult<Vec<String>> {
+        Ok(self.0.agents().clone())
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
     }
 
     fn __repr__(&self) -> PyResult<String> {
         self.__str__()
+    }
+}
+
+impl From<destination::Destination> for Destination {
+    fn from(destination: destination::Destination) -> Self {
+        Destination(destination)
+    }
+}
+
+#[pyclass]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Instruction(grammar::Instruction);
+
+#[pymethods]
+impl Instruction {
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        self.__str__()
+    }
+}
+
+impl From<grammar::Instruction> for Instruction {
+    fn from(instruction: grammar::Instruction) -> Self {
+        Instruction(instruction)
+    }
+}
+
+#[pyclass]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Uuid(uuid::Uuid);
+
+#[pymethods]
+impl Uuid {
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        self.__str__()
+    }
+}
+
+impl From<uuid::Uuid> for Uuid {
+    fn from(uuid: uuid::Uuid) -> Self {
+        Uuid(uuid)
+    }
+}
+
+#[pyclass]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Status(job::Status);
+
+#[pymethods]
+impl Status {
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        self.__str__()
+    }
+}
+
+impl From<job::Status> for Status {
+    fn from(status: job::Status) -> Self {
+        Status(status)
+    }
+}
+
+#[pyclass]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UserIdentifier(grammar::UserIdentifier);
+
+#[pymethods]
+impl UserIdentifier {
+    #[getter]
+    fn username(&self) -> PyResult<String> {
+        Ok(self.0.username().clone())
+    }
+
+    #[getter]
+    fn project(&self) -> PyResult<String> {
+        Ok(self.0.project().clone())
+    }
+
+    #[getter]
+    fn portal(&self) -> PyResult<String> {
+        Ok(self.0.portal().clone())
+    }
+
+    #[getter]
+    fn project_identifier(&self) -> PyResult<ProjectIdentifier> {
+        Ok(self.0.project_identifier().clone().into())
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        self.__str__()
+    }
+}
+
+impl From<grammar::UserIdentifier> for UserIdentifier {
+    fn from(user_identifier: grammar::UserIdentifier) -> Self {
+        UserIdentifier(user_identifier)
+    }
+}
+
+#[pyclass]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProjectIdentifier(grammar::ProjectIdentifier);
+
+#[pymethods]
+impl ProjectIdentifier {
+    #[getter]
+    fn project(&self) -> PyResult<String> {
+        Ok(self.0.project().clone())
+    }
+
+    #[getter]
+    fn portal(&self) -> PyResult<String> {
+        Ok(self.0.portal().clone())
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        self.__str__()
+    }
+}
+
+impl From<grammar::ProjectIdentifier> for ProjectIdentifier {
+    fn from(project_identifier: grammar::ProjectIdentifier) -> Self {
+        ProjectIdentifier(project_identifier)
+    }
+}
+
+#[pyclass]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UserMapping(grammar::UserMapping);
+
+#[pymethods]
+impl UserMapping {
+    #[getter]
+    fn user(&self) -> PyResult<UserIdentifier> {
+        Ok(self.0.user().clone().into())
+    }
+
+    #[getter]
+    fn local_user(&self) -> PyResult<String> {
+        Ok(self.0.local_user().to_string())
+    }
+
+    #[getter]
+    fn local_project(&self) -> PyResult<String> {
+        Ok(self.0.local_project().to_string())
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        self.__str__()
+    }
+}
+
+impl From<grammar::UserMapping> for UserMapping {
+    fn from(user_mapping: grammar::UserMapping) -> Self {
+        UserMapping(user_mapping)
+    }
+}
+
+#[pyclass]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProjectMapping(grammar::ProjectMapping);
+
+#[pymethods]
+impl ProjectMapping {
+    #[getter]
+    fn project(&self) -> PyResult<ProjectIdentifier> {
+        Ok(self.0.project().clone().into())
+    }
+
+    #[getter]
+    fn local_project(&self) -> PyResult<String> {
+        Ok(self.0.local_project().to_string())
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        self.__str__()
+    }
+}
+
+impl From<grammar::ProjectMapping> for ProjectMapping {
+    fn from(project_mapping: grammar::ProjectMapping) -> Self {
+        ProjectMapping(project_mapping)
     }
 }
 
@@ -488,8 +690,8 @@ impl Job {
 ///
 #[pyfunction]
 fn run(command: String) -> PyResult<Job> {
-    match call_post::<Job>("run", serde_json::json!({"command": command})) {
-        Ok(response) => Ok(response),
+    match call_post::<job::Job>("run", serde_json::json!({"command": command})) {
+        Ok(response) => Ok(response.into()),
         Err(e) => Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
     }
 }
@@ -500,8 +702,8 @@ fn run(command: String) -> PyResult<Job> {
 ///
 #[pyfunction]
 fn status(job: Job) -> PyResult<Job> {
-    match call_post::<Job>("status", serde_json::json!({"job": job.id})) {
-        Ok(response) => Ok(response),
+    match call_post::<job::Job>("status", serde_json::json!({"job": job.0.id().to_string()})) {
+        Ok(response) => Ok(response.into()),
         Err(e) => Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
     }
 }
@@ -512,8 +714,8 @@ fn status(job: Job) -> PyResult<Job> {
 ///
 #[pyfunction]
 fn get(job_id: &str) -> PyResult<Job> {
-    match call_post::<Job>("status", serde_json::json!({"job": job_id.to_string()})) {
-        Ok(response) => Ok(response),
+    match call_post::<job::Job>("status", serde_json::json!({"job": job_id.to_string()})) {
+        Ok(response) => Ok(response.into()),
         Err(e) => Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -260,6 +260,14 @@ impl From<job::Job> for Job {
 
 #[pymethods]
 impl Job {
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        self.__str__()
+    }
+
     #[getter]
     fn id(&self) -> PyResult<Uuid> {
         Ok(self.0.id().into())
@@ -515,6 +523,21 @@ impl Uuid {
     fn __repr__(&self) -> PyResult<String> {
         self.__str__()
     }
+
+    #[staticmethod]
+    fn from_string(uuid: &str) -> PyResult<Uuid> {
+        Ok(Uuid::from(uuid.to_string()))
+    }
+
+    fn to_string(&self) -> PyResult<String> {
+        Ok(self.0.to_string())
+    }
+}
+
+impl From<String> for Uuid {
+    fn from(uuid: String) -> Self {
+        Uuid(uuid::Uuid::parse_str(&uuid).unwrap())
+    }
 }
 
 impl From<uuid::Uuid> for Uuid {
@@ -633,8 +656,8 @@ impl UserMapping {
     }
 
     #[getter]
-    fn local_project(&self) -> PyResult<String> {
-        Ok(self.0.local_project().to_string())
+    fn local_group(&self) -> PyResult<String> {
+        Ok(self.0.local_group().to_string())
     }
 
     fn __str__(&self) -> PyResult<String> {
@@ -664,8 +687,8 @@ impl ProjectMapping {
     }
 
     #[getter]
-    fn local_project(&self) -> PyResult<String> {
-        Ok(self.0.local_project().to_string())
+    fn local_group(&self) -> PyResult<String> {
+        Ok(self.0.local_group().to_string())
     }
 
     fn __str__(&self) -> PyResult<String> {
@@ -713,8 +736,8 @@ fn status(job: Job) -> PyResult<Job> {
 /// job does not exist.
 ///
 #[pyfunction]
-fn get(job_id: &str) -> PyResult<Job> {
-    match call_post::<job::Job>("status", serde_json::json!({"job": job_id.to_string()})) {
+fn get(job_id: &Uuid) -> PyResult<Job> {
+    match call_post::<job::Job>("status", serde_json::json!({"job": job_id.to_string()?})) {
         Ok(response) => Ok(response.into()),
         Err(e) => Err(PyErr::new::<PyOSError, _>(format!("{:?}", e))),
     }

--- a/slurm/src/main.rs
+++ b/slurm/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
                 match job.instruction() {
                     AddLocalProject(project) => {
                         sacctmgr::add_project(&project).await?;
-                        let job = job.completed("Success!")?;
+                        let job = job.completed("Success!".to_string())?;
                         Ok(job)
                     },
                     RemoveLocalProject(project) => {
@@ -101,7 +101,7 @@ async fn main() -> Result<()> {
                     },
                     AddLocalUser(user) => {
                         sacctmgr::add_user(&user).await?;
-                        let job = job.completed("Success!")?;
+                        let job = job.completed("Success!".to_string())?;
                         Ok(job)
                     },
                     RemoveLocalUser(mapping) => {
@@ -169,7 +169,7 @@ async fn main() -> Result<()> {
                 match job.instruction() {
                     AddLocalProject(project) => {
                         slurm::add_project(&project).await?;
-                        let job = job.completed("Success!")?;
+                        let job = job.completed("Success!".to_string())?;
                         Ok(job)
                     },
                     RemoveLocalProject(project) => {
@@ -179,7 +179,7 @@ async fn main() -> Result<()> {
                     },
                     AddLocalUser(user) => {
                         slurm::add_user(&user).await?;
-                        let job = job.completed("Success!")?;
+                        let job = job.completed("Success!".to_string())?;
                         Ok(job)
                     },
                     RemoveLocalUser(mapping) => {

--- a/slurm/src/main.rs
+++ b/slurm/src/main.rs
@@ -6,7 +6,9 @@ use anyhow::Result;
 use templemeads::agent::scheduler::{process_args, run, Defaults};
 use templemeads::agent::Type as AgentType;
 use templemeads::async_runnable;
-use templemeads::grammar::Instruction::{AddLocalUser, RemoveLocalUser};
+use templemeads::grammar::Instruction::{
+    AddLocalProject, AddLocalUser, RemoveLocalProject, RemoveLocalUser,
+};
 use templemeads::job::{Envelope, Job};
 use templemeads::Error;
 
@@ -87,6 +89,16 @@ async fn main() -> Result<()> {
                 let job = envelope.job();
 
                 match job.instruction() {
+                    AddLocalProject(project) => {
+                        sacctmgr::add_project(&project).await?;
+                        let job = job.completed("Success!")?;
+                        Ok(job)
+                    },
+                    RemoveLocalProject(project) => {
+                        Err(Error::IncompleteCode(
+                            format!("RemoveLocalProject instruction not implemented yet - cannot remove {}", project),
+                        ))
+                    },
                     AddLocalUser(user) => {
                         sacctmgr::add_user(&user).await?;
                         let job = job.completed("Success!")?;
@@ -155,6 +167,16 @@ async fn main() -> Result<()> {
                 let job = envelope.job();
 
                 match job.instruction() {
+                    AddLocalProject(project) => {
+                        slurm::add_project(&project).await?;
+                        let job = job.completed("Success!")?;
+                        Ok(job)
+                    },
+                    RemoveLocalProject(project) => {
+                        Err(Error::IncompleteCode(
+                            format!("RemoveLocalProject instruction not implemented yet - cannot remove {}", project),
+                        ))
+                    },
                     AddLocalUser(user) => {
                         slurm::add_user(&user).await?;
                         let job = job.completed("Success!")?;

--- a/slurm/src/sacctmgr.rs
+++ b/slurm/src/sacctmgr.rs
@@ -4,7 +4,7 @@
 use anyhow::Context;
 use anyhow::Result;
 use once_cell::sync::Lazy;
-use templemeads::grammar::UserMapping;
+use templemeads::grammar::{ProjectMapping, UserMapping};
 use templemeads::Error;
 use tokio::sync::{Mutex, MutexGuard};
 
@@ -569,7 +569,8 @@ async fn add_user_association(
 async fn get_user_create_if_not_exists(user: &UserMapping) -> Result<SlurmUser, Error> {
     // first, make sure that the account exists
     let slurm_account =
-        get_account_create_if_not_exists(&SlurmAccount::from_mapping(user)?).await?;
+        get_account_create_if_not_exists(&SlurmAccount::from_mapping(&user.clone().into())?)
+            .await?;
 
     // now get the user from slurm
     let slurm_user = get_user(user.local_user()).await?;
@@ -682,6 +683,16 @@ pub async fn find_cluster() -> Result<(), Error> {
         );
         cache::set_cluster(&clusters[0]).await?;
     }
+
+    Ok(())
+}
+
+pub async fn add_project(project: &ProjectMapping) -> Result<(), Error> {
+    let account = SlurmAccount::from_mapping(project)?;
+
+    let account = get_account_create_if_not_exists(&account).await?;
+
+    tracing::info!("Added account: {}", account);
 
     Ok(())
 }

--- a/slurm/src/sacctmgr.rs
+++ b/slurm/src/sacctmgr.rs
@@ -596,7 +596,7 @@ async fn get_user_create_if_not_exists(user: &UserMapping) -> Result<SlurmUser, 
 
     // first, create the user
     let username = clean_user_name(user.local_user())?;
-    let account = clean_account_name(user.local_project())?;
+    let account = clean_account_name(user.local_group())?;
 
     let cluster = cache::get_cluster().await?;
 

--- a/slurm/src/slurm.rs
+++ b/slurm/src/slurm.rs
@@ -1359,7 +1359,7 @@ impl Display for SlurmAccount {
 impl SlurmAccount {
     pub fn from_mapping(mapping: &ProjectMapping) -> Result<Self, Error> {
         Ok(SlurmAccount {
-            name: clean_account_name(mapping.local_project())?,
+            name: clean_account_name(mapping.local_group())?,
             description: format!("Account for OpenPortal project {}", mapping.project()),
             organization: get_managed_organization(),
         })
@@ -1471,7 +1471,7 @@ impl SlurmAssociation {
     pub fn from_mapping(mapping: &UserMapping) -> Result<Self, Error> {
         Ok(SlurmAssociation {
             user: clean_user_name(mapping.local_user())?,
-            account: clean_account_name(mapping.local_project())?,
+            account: clean_account_name(mapping.local_group())?,
         })
     }
 
@@ -1563,7 +1563,7 @@ impl SlurmUser {
     pub fn from_mapping(mapping: &UserMapping) -> Result<Self, Error> {
         Ok(SlurmUser {
             name: mapping.local_user().to_string(),
-            default_account: Some(clean_account_name(mapping.local_project())?),
+            default_account: Some(clean_account_name(mapping.local_group())?),
             associations: vec![SlurmAssociation::from_mapping(mapping)?],
         })
     }

--- a/slurm/src/slurm.rs
+++ b/slurm/src/slurm.rs
@@ -9,7 +9,7 @@ use secrecy::{ExposeSecret, Secret};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Display;
-use templemeads::grammar::UserMapping;
+use templemeads::grammar::{ProjectMapping, UserMapping};
 use templemeads::Error;
 use tokio::sync::{Mutex, MutexGuard};
 
@@ -1229,7 +1229,8 @@ async fn add_user_association(
 async fn get_user_create_if_not_exists(user: &UserMapping) -> Result<SlurmUser, Error> {
     // first, make sure that the account exists
     let slurm_account =
-        get_account_create_if_not_exists(&SlurmAccount::from_mapping(user)?).await?;
+        get_account_create_if_not_exists(&SlurmAccount::from_mapping(&user.clone().into())?)
+            .await?;
 
     // now get the user from slurm
     let slurm_user = get_user(user.local_user()).await?;
@@ -1356,13 +1357,10 @@ impl Display for SlurmAccount {
 }
 
 impl SlurmAccount {
-    pub fn from_mapping(mapping: &UserMapping) -> Result<Self, Error> {
+    pub fn from_mapping(mapping: &ProjectMapping) -> Result<Self, Error> {
         Ok(SlurmAccount {
             name: clean_account_name(mapping.local_project())?,
-            description: format!(
-                "Account for OpenPortal project {}",
-                mapping.user().project()
-            ),
+            description: format!("Account for OpenPortal project {}", mapping.project()),
             organization: get_managed_organization(),
         })
     }
@@ -1713,6 +1711,16 @@ pub async fn add_user(user: &UserMapping) -> Result<(), Error> {
     let user: SlurmUser = get_user_create_if_not_exists(user).await?;
 
     tracing::info!("Added user: {}", user);
+
+    Ok(())
+}
+
+pub async fn add_project(project: &ProjectMapping) -> Result<(), Error> {
+    let account = SlurmAccount::from_mapping(project)?;
+
+    let account = get_account_create_if_not_exists(&account).await?;
+
+    tracing::info!("Added account: {}", account);
 
     Ok(())
 }

--- a/templemeads/src/bridge.rs
+++ b/templemeads/src/bridge.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use uuid::Uuid;
 
 pub async fn status(job: &Uuid) -> Result<Job, Error> {
-    tracing::info!("Received status request for job: {}", job);
+    tracing::debug!("Received status request for job: {}", job);
 
     match agent::portal(30).await {
         Some(portal) => {

--- a/templemeads/src/bridge_server.rs
+++ b/templemeads/src/bridge_server.rs
@@ -302,7 +302,7 @@ async fn health(
     State(state): State<AppState>,
 ) -> Result<Json<serde_json::Value>, AppError> {
     verify_headers(&state, &headers, "get", "health", None)?;
-    tracing::info!("Health check");
+    tracing::debug!("Health check");
     Ok(Json(json!({"status": "ok"})))
 }
 
@@ -372,7 +372,7 @@ async fn status(
         Some(serde_json::json!({"job": payload.job})),
     )?;
 
-    tracing::info!("Status request for job: {:?}", payload);
+    tracing::debug!("Status request for job: {:?}", payload);
 
     match bridge_status(&payload.job).await {
         Ok(job) => Ok(Json(job)),

--- a/templemeads/src/grammar.rs
+++ b/templemeads/src/grammar.rs
@@ -70,6 +70,15 @@ impl std::fmt::Display for ProjectIdentifier {
     }
 }
 
+impl From<UserIdentifier> for ProjectIdentifier {
+    fn from(user: UserIdentifier) -> Self {
+        Self {
+            project: user.project().to_string(),
+            portal: user.portal().to_string(),
+        }
+    }
+}
+
 /// Serialize and Deserialize via the string representation
 
 impl Serialize for ProjectIdentifier {
@@ -261,6 +270,15 @@ impl ProjectMapping {
 impl std::fmt::Display for ProjectMapping {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}", self.project, self.local_project)
+    }
+}
+
+impl From<UserMapping> for ProjectMapping {
+    fn from(mapping: UserMapping) -> Self {
+        Self {
+            project: mapping.user().project_identifier(),
+            local_project: mapping.local_project().to_string(),
+        }
     }
 }
 

--- a/templemeads/src/grammar.rs
+++ b/templemeads/src/grammar.rs
@@ -233,7 +233,7 @@ impl<'de> Deserialize<'de> for UserIdentifier {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ProjectMapping {
     project: ProjectIdentifier,
-    local_project: String,
+    local_group: String,
 }
 
 impl NamedType for ProjectMapping {
@@ -243,30 +243,30 @@ impl NamedType for ProjectMapping {
 }
 
 impl ProjectMapping {
-    pub fn new(project: &ProjectIdentifier, local_project: &str) -> Result<Self, Error> {
-        let local_project = local_project.trim();
+    pub fn new(project: &ProjectIdentifier, local_group: &str) -> Result<Self, Error> {
+        let local_group = local_group.trim();
 
-        if local_project.is_empty() {
+        if local_group.is_empty() {
             return Err(Error::Parse(format!(
-                "Invalid ProjectMapping - local_project cannot be empty '{}'",
-                local_project
+                "Invalid ProjectMapping - local_group cannot be empty '{}'",
+                local_group
             )));
         };
 
-        if local_project.starts_with(".")
-            || local_project.ends_with(".")
-            || local_project.starts_with("/")
-            || local_project.ends_with("/")
+        if local_group.starts_with(".")
+            || local_group.ends_with(".")
+            || local_group.starts_with("/")
+            || local_group.ends_with("/")
         {
             return Err(Error::Parse(format!(
-                "Invalid ProjectMapping - local project contains invalid characters '{}'",
-                local_project
+                "Invalid ProjectMapping - local group contains invalid characters '{}'",
+                local_group
             )));
         };
 
         Ok(Self {
             project: project.clone(),
-            local_project: local_project.to_string(),
+            local_group: local_group.to_string(),
         })
     }
 
@@ -281,23 +281,23 @@ impl ProjectMapping {
         }
 
         let project = ProjectIdentifier::parse(parts[0])?;
-        let local_project = parts[1].trim();
+        let local_group = parts[1].trim();
 
-        Self::new(&project, local_project)
+        Self::new(&project, local_group)
     }
 
     pub fn project(&self) -> &ProjectIdentifier {
         &self.project
     }
 
-    pub fn local_project(&self) -> &str {
-        &self.local_project
+    pub fn local_group(&self) -> &str {
+        &self.local_group
     }
 }
 
 impl std::fmt::Display for ProjectMapping {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.project, self.local_project)
+        write!(f, "{}:{}", self.project, self.local_group)
     }
 }
 
@@ -305,7 +305,7 @@ impl From<UserMapping> for ProjectMapping {
     fn from(mapping: UserMapping) -> Self {
         Self {
             project: mapping.user().project_identifier(),
-            local_project: mapping.local_project().to_string(),
+            local_group: mapping.local_group().to_string(),
         }
     }
 }
@@ -339,7 +339,7 @@ impl<'de> Deserialize<'de> for ProjectMapping {
 pub struct UserMapping {
     user: UserIdentifier,
     local_user: String,
-    local_project: String,
+    local_group: String,
 }
 
 impl NamedType for UserMapping {
@@ -349,13 +349,9 @@ impl NamedType for UserMapping {
 }
 
 impl UserMapping {
-    pub fn new(
-        user: &UserIdentifier,
-        local_user: &str,
-        local_project: &str,
-    ) -> Result<Self, Error> {
+    pub fn new(user: &UserIdentifier, local_user: &str, local_group: &str) -> Result<Self, Error> {
         let local_user = local_user.trim();
-        let local_project = local_project.trim();
+        let local_group = local_group.trim();
 
         if local_user.is_empty() {
             return Err(Error::Parse(format!(
@@ -370,33 +366,33 @@ impl UserMapping {
             || local_user.ends_with("/")
         {
             return Err(Error::Parse(format!(
-                "Invalid UserMapping - local user account contains invalid characters '{}'",
+                "Invalid UserMapping - local_user account contains invalid characters '{}'",
                 local_user
             )));
         };
 
-        if local_project.is_empty() {
+        if local_group.is_empty() {
             return Err(Error::Parse(format!(
-                "Invalid UserMapping - local_project cannot be empty '{}'",
-                local_project
+                "Invalid UserMapping - local_group cannot be empty '{}'",
+                local_group
             )));
         };
 
-        if local_project.starts_with(".")
-            || local_project.ends_with(".")
-            || local_project.starts_with("/")
-            || local_project.ends_with("/")
+        if local_group.starts_with(".")
+            || local_group.ends_with(".")
+            || local_group.starts_with("/")
+            || local_group.ends_with("/")
         {
             return Err(Error::Parse(format!(
-                "Invalid UserMapping - local project contains invalid characters '{}'",
-                local_project
+                "Invalid UserMapping - local_group contains invalid characters '{}'",
+                local_group
             )));
         };
 
         Ok(Self {
             user: user.clone(),
             local_user: local_user.to_string(),
-            local_project: local_project.to_string(),
+            local_group: local_group.to_string(),
         })
     }
 
@@ -409,9 +405,9 @@ impl UserMapping {
 
         let user = UserIdentifier::parse(parts[0])?;
         let local_user = parts[1].trim();
-        let local_project = parts[2].trim();
+        let local_group = parts[2].trim();
 
-        Self::new(&user, local_user, local_project)
+        Self::new(&user, local_user, local_group)
     }
 
     pub fn user(&self) -> &UserIdentifier {
@@ -422,18 +418,14 @@ impl UserMapping {
         &self.local_user
     }
 
-    pub fn local_project(&self) -> &str {
-        &self.local_project
+    pub fn local_group(&self) -> &str {
+        &self.local_group
     }
 }
 
 impl std::fmt::Display for UserMapping {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}:{}:{}",
-            self.user, self.local_user, self.local_project
-        )
+        write!(f, "{}:{}:{}", self.user, self.local_user, self.local_group)
     }
 }
 
@@ -744,20 +736,20 @@ mod tests {
     #[test]
     fn test_user_mapping() {
         let user = UserIdentifier::parse("user.project.portal").unwrap_or_default();
-        let mapping = UserMapping::new(&user, "local_user", "local_project").unwrap_or_default();
+        let mapping = UserMapping::new(&user, "local_user", "local_group").unwrap_or_default();
         assert_eq!(mapping.user(), &user);
         assert_eq!(mapping.local_user(), "local_user");
-        assert_eq!(mapping.local_project(), "local_project");
+        assert_eq!(mapping.local_group(), "local_group");
         assert_eq!(
             mapping.to_string(),
-            "user.project.portal:local_user:local_project"
+            "user.project.portal:local_user:local_group"
         );
     }
 
     #[test]
     fn test_instruction() {
         let user = UserIdentifier::parse("user.project.portal").unwrap_or_default();
-        let mapping = UserMapping::new(&user, "local_user", "local_project").unwrap_or_default();
+        let mapping = UserMapping::new(&user, "local_user", "local_group").unwrap_or_default();
 
         #[allow(clippy::unwrap_used)]
         let instruction = Instruction::parse("add_user user.project.portal").unwrap();
@@ -769,13 +761,13 @@ mod tests {
 
         #[allow(clippy::unwrap_used)]
         let instruction =
-            Instruction::parse("add_local_user user.project.portal:local_user:local_project")
+            Instruction::parse("add_local_user user.project.portal:local_user:local_group")
                 .unwrap();
         assert_eq!(instruction, Instruction::AddLocalUser(mapping.clone()));
 
         #[allow(clippy::unwrap_used)]
         let instruction =
-            Instruction::parse("remove_local_user user.project.portal:local_user:local_project")
+            Instruction::parse("remove_local_user user.project.portal:local_user:local_group")
                 .unwrap();
         assert_eq!(instruction, Instruction::RemoveLocalUser(mapping.clone()));
 
@@ -805,29 +797,26 @@ mod tests {
     #[test]
     fn assert_serialize_mapping() {
         let user = UserIdentifier::parse("user.project.portal").unwrap_or_default();
-        let mapping = UserMapping::new(&user, "local_user", "local_project").unwrap_or_default();
+        let mapping = UserMapping::new(&user, "local_user", "local_group").unwrap_or_default();
         let serialized = serde_json::to_string(&mapping).unwrap_or_default();
-        assert_eq!(
-            serialized,
-            "\"user.project.portal:local_user:local_project\""
-        );
+        assert_eq!(serialized, "\"user.project.portal:local_user:local_group\"");
     }
 
     #[test]
     fn assert_deserialize_mapping() {
         let mapping: UserMapping =
-            serde_json::from_str("\"user.project.portal:local_user:local_project\"")
+            serde_json::from_str("\"user.project.portal:local_user:local_group\"")
                 .unwrap_or_default();
         assert_eq!(
             mapping.to_string(),
-            "user.project.portal:local_user:local_project"
+            "user.project.portal:local_user:local_group"
         );
     }
 
     #[test]
     fn assert_serialize_instruction() {
         let user = UserIdentifier::parse("user.project.portal").unwrap_or_default();
-        let mapping = UserMapping::new(&user, "local_user", "local_project").unwrap_or_default();
+        let mapping = UserMapping::new(&user, "local_user", "local_group").unwrap_or_default();
 
         let instruction = Instruction::AddUser(user.clone());
         let serialized = serde_json::to_string(&instruction).unwrap_or_default();
@@ -841,14 +830,14 @@ mod tests {
         let serialized = serde_json::to_string(&instruction).unwrap_or_default();
         assert_eq!(
             serialized,
-            "\"add_local_user user.project.portal:local_user:local_project\""
+            "\"add_local_user user.project.portal:local_user:local_group\""
         );
 
         let instruction = Instruction::RemoveLocalUser(mapping.clone());
         let serialized = serde_json::to_string(&instruction).unwrap_or_default();
         assert_eq!(
             serialized,
-            "\"remove_local_user user.project.portal:local_user:local_project\""
+            "\"remove_local_user user.project.portal:local_user:local_group\""
         );
 
         let instruction = Instruction::UpdateHomeDir(user.clone(), "/home/user".to_string());
@@ -864,7 +853,7 @@ mod tests {
         #[allow(clippy::unwrap_used)]
         let user = UserIdentifier::parse("user.project.portal").unwrap();
         #[allow(clippy::unwrap_used)]
-        let mapping = UserMapping::new(&user, "local_user", "local_project").unwrap();
+        let mapping = UserMapping::new(&user, "local_user", "local_group").unwrap();
 
         #[allow(clippy::unwrap_used)]
         let instruction: Instruction =
@@ -878,13 +867,13 @@ mod tests {
 
         #[allow(clippy::unwrap_used)]
         let instruction: Instruction =
-            serde_json::from_str("\"add_local_user user.project.portal:local_user:local_project\"")
+            serde_json::from_str("\"add_local_user user.project.portal:local_user:local_group\"")
                 .unwrap();
         assert_eq!(instruction, Instruction::AddLocalUser(mapping.clone()));
 
         #[allow(clippy::unwrap_used)]
         let instruction: Instruction = serde_json::from_str(
-            "\"remove_local_user user.project.portal:local_user:local_project\"",
+            "\"remove_local_user user.project.portal:local_user:local_group\"",
         )
         .unwrap();
         assert_eq!(instruction, Instruction::RemoveLocalUser(mapping.clone()));

--- a/templemeads/src/grammar.rs
+++ b/templemeads/src/grammar.rs
@@ -8,6 +8,16 @@ use std::sync::Arc;
 
 /// Grammar for all of the commands that can be sent to agents
 
+pub trait NamedType {
+    fn type_name() -> &'static str;
+}
+
+impl NamedType for String {
+    fn type_name() -> &'static str {
+        "String"
+    }
+}
+
 ///
 /// A project identifier - this is a double of project.portal
 ///
@@ -15,6 +25,12 @@ use std::sync::Arc;
 pub struct ProjectIdentifier {
     project: String,
     portal: String,
+}
+
+impl NamedType for ProjectIdentifier {
+    fn type_name() -> &'static str {
+        "ProjectIdentifier"
+    }
 }
 
 impl ProjectIdentifier {
@@ -108,6 +124,12 @@ pub struct UserIdentifier {
     username: String,
     project: String,
     portal: String,
+}
+
+impl NamedType for UserIdentifier {
+    fn type_name() -> &'static str {
+        "UserIdentifier"
+    }
 }
 
 impl UserIdentifier {
@@ -214,6 +236,12 @@ pub struct ProjectMapping {
     local_project: String,
 }
 
+impl NamedType for ProjectMapping {
+    fn type_name() -> &'static str {
+        "ProjectMapping"
+    }
+}
+
 impl ProjectMapping {
     pub fn new(project: &ProjectIdentifier, local_project: &str) -> Result<Self, Error> {
         let local_project = local_project.trim();
@@ -312,6 +340,12 @@ pub struct UserMapping {
     user: UserIdentifier,
     local_user: String,
     local_project: String,
+}
+
+impl NamedType for UserMapping {
+    fn type_name() -> &'static str {
+        "UserMapping"
+    }
 }
 
 impl UserMapping {

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -219,11 +219,17 @@ pub struct Job {
 impl std::fmt::Display for Job {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.state {
-            Status::Created => write!(f, "{{{}}}: Created", self.command),
-            Status::Pending => write!(f, "{{{}}}: Pending", self.command),
-            Status::Running => write!(f, "{{{}}}: Running", self.command),
-            Status::Complete => write!(f, "{{{}}}: Complete - {:?}", self.command, self.result),
-            Status::Error => write!(f, "{{{}}}: Error - {:?}", self.command, self.result),
+            Status::Created => write!(f, "{{{}: Created}}", self.command),
+            Status::Pending => write!(f, "{{{}: Pending}}", self.command),
+            Status::Running => write!(f, "{{{}: Running}}", self.command),
+            Status::Complete => match self.result.clone() {
+                Some(result) => write!(f, "{{{}: Complete - {}}}", self.command, result),
+                None => write!(f, "{{{}: Complete}}", self.command),
+            },
+            Status::Error => match self.result.clone() {
+                Some(result) => write!(f, "{{{}: Error - {}}}", self.command, result),
+                None => write!(f, "{{{}: Unknown Error}}", self.command),
+            },
         }
     }
 }

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -110,6 +110,26 @@ impl Command {
                 )));
                 }
             }
+
+            let project = match instruction.clone() {
+                Instruction::AddProject(project) => Some(project),
+                Instruction::GetUsers(project) => Some(project),
+                Instruction::RemoveProject(project) => Some(project),
+                _ => None,
+            };
+
+            if let Some(project) = project {
+                if project.portal() != destination.first() {
+                    tracing::error!(
+                    "Invalid command '{}'. Commands involving project '{}' can only be issued via the portal '{}', not '{}'.",
+                    command, project, project.portal(), destination.first()
+                );
+                    return Err(Error::Parse(format!(
+                    "Invalid command '{}'. Commands involving project '{}' can only be issued via the portal '{}', not '{}'.",
+                    command, project, project.portal(), destination.first()
+                )));
+                }
+            }
         }
 
         Ok(Self {

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -13,6 +13,7 @@ use anyhow::Result;
 use chrono::serde::ts_seconds;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -53,6 +54,18 @@ pub enum Status {
     Running,
     Complete,
     Error,
+}
+
+impl Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Status::Created => write!(f, "created"),
+            Status::Pending => write!(f, "pending"),
+            Status::Running => write!(f, "running"),
+            Status::Complete => write!(f, "complete"),
+            Status::Error => write!(f, "error"),
+        }
+    }
 }
 
 ///
@@ -473,6 +486,22 @@ impl Job {
             Status::Pending => Some("Pending".to_owned()),
             Status::Complete => Some("Complete".to_owned()),
             Status::Error => Some("Error".to_owned()),
+        }
+    }
+
+    pub fn result_type(&self) -> Result<String, Error> {
+        match self.state {
+            Status::Created => Ok("None".to_string()),
+            Status::Pending => Ok("None".to_string()),
+            Status::Running => Ok("None".to_string()),
+            Status::Error => match &self.result_type {
+                Some(t) => Ok(t.clone()),
+                None => Ok("Error".to_string()),
+            },
+            Status::Complete => match &self.result_type {
+                Some(t) => Ok(t.clone()),
+                None => Ok("None".to_string()),
+            },
         }
     }
 

--- a/templemeads/src/portal.rs
+++ b/templemeads/src/portal.rs
@@ -93,15 +93,8 @@ crate::async_runnable! {
                     }
                  }
                  else {
-                    match southbound_job.result::<String>() {
-                        Ok(result) => {
-                            job = job.completed(result)?;
-                        }
-                        Err(e) => {
-                            job = job.errored(&format!("ResultError{{{}}}", e))?;
-                        }
-                    }
-                 }
+                    job = job.copy_result_from(&southbound_job)?;
+                }
 
                 Ok(job)
             }


### PR DESCRIPTION
Functionality that makes it easier to interface with Waldur.

### Added
- Added some extra functions to the Python layer to make it easier to
  integrate OpenPortal with, e.g. Waldur. These include `is_config_loaded`
  to check if the config has been loaded, and `get` to get the
  Job that matches the passed ID.

- Added automatic building of Python Linux aarch64 binaries, so that
  the Python module can be used on ARM64 systems.

- Cleaned up the Python API and added in lots of convenience functions.
  Objects are now correctly returned from the `run` function, so that you
  don't need to parse anything. Also added in the ability to default
  wait for a command to run

- Added in extra commands to add and remove projects, list users in a
  project, and list projects in a portal. Some of these are still stubbed.

- Added in `ProjectIdentifier` and `ProjectMapping` to mirror the
  equivalent `User` classes. Also cleaned up the concept of local
  users and groups, so that a `UserMapping` maps a user to a local
  unix username and unix group, while the `ProjectMapping` maps a
  project to a local unix group.