### PR TITLE
Feature portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ invite*.toml
 example*.toml
 slurm_example_data*
 slurm_demo_data*
+agents/*.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.11.0] - 2025-05-21
 ### Added
 - Added support for high availability (HA) for client OpenPortal agents.
   This allows for client agents to be run on multiple nodes, with only
@@ -15,7 +17,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   as both servers and clients. There should still only be a single
   instance of such agents in a network. HA for server agents
   in planned.
-
 - Added command line options to support rotating of client and server
   keys. Use the `client --rotate name --zone zone` on a server to
   rotate the keys for the specified client in the specified zone. This
@@ -418,6 +419,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Initial release
   This is an initial alpha release of the OpenPortal project. It is not yet feature complete and is not recommended for production use.
 
+[0.11.0]: https://github.com/isambard-sc/openportal/releases/tag/0.11.0
 [0.10.0]: https://github.com/isambard-sc/openportal/releases/tag/0.10.0
 [0.9.6]: https://github.com/isambard-sc/openportal/releases/tag/0.9.6
 [0.9.5]: https://github.com/isambard-sc/openportal/releases/tag/0.9.5

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version="1.0.95", features = ["backtrace"] }
 dirs = "6.0.0"
 templemeads = { path = "../templemeads" }
 tokio = { version = "1.43", features = ["full"] }
-
+tracing = "0.1.41"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -3,7 +3,14 @@
 
 use anyhow::Result;
 
+use templemeads::agent;
 use templemeads::agent::bridge::{process_args, run, Defaults};
+use templemeads::agent::Type::Portal;
+use templemeads::async_runnable;
+use templemeads::grammar::Instruction::{CreateProject, UpdateProject};
+use templemeads::grammar::{ProjectDetails, ProjectIdentifier, ProjectMapping};
+use templemeads::job::{Envelope, Job};
+use templemeads::Error;
 
 ///
 /// Main function for the bridge application
@@ -54,8 +61,75 @@ async fn main() -> Result<()> {
         }
     };
 
+    async_runnable! {
+        ///
+        /// Runnable function that will be called when a job is received
+        /// by the agent
+        ///
+        pub async fn bridge_runner(envelope: Envelope) -> Result<Job, Error>
+        {
+            let job = envelope.job();
+
+            // Get information about the agent that sent this job
+            // The only agents that can send jobs to a portal are
+            // bridge agents, and other portal agents that have
+            // expressly be configured to be given permission.
+            // This permission is based on the zone of the portal to portal
+            // connection
+            match agent::agent_type(&envelope.sender()).await {
+                Some(Portal) => {}
+                _ => {
+                    return Err(Error::InvalidInstruction(
+                        format!("Invalid instruction: {}. Only portal agents can submit instructions to a bridge", job.instruction()),
+                    ));
+                }
+            }
+
+            match job.instruction() {
+                CreateProject(project, details) => {
+                    // create a new project in the cluster
+                    tracing::debug!("Creating project {} with details {:?}", project, details);
+                    job.completed(create_project(&project, &details).await?)
+                }
+                UpdateProject(project, details) => {
+                    // update the project in the cluster
+                    tracing::debug!("Updating project {} with details {:?}", project, details);
+                    job.completed(update_project(&project, &details).await?)
+                }
+                _ => {
+                    tracing::error!("Unknown instruction: {:?}", job.instruction());
+                    Err(Error::UnknownInstruction(
+                        format!("Unknown instruction: {:?}", job.instruction()).to_string(),
+                    ))
+                }
+            }
+        }
+    }
+
     // run the Bridge agent
-    run(config).await?;
+    run(config, bridge_runner).await?;
 
     Ok(())
+}
+
+async fn create_project(
+    project: &ProjectIdentifier,
+    details: &ProjectDetails,
+) -> Result<ProjectMapping, Error> {
+    tracing::info!("Creating project {} with details {:?}", project, details);
+
+    Err(Error::IncompleteCode(
+        "Create project not implemented".to_string(),
+    ))
+}
+
+async fn update_project(
+    project: &ProjectIdentifier,
+    details: &ProjectDetails,
+) -> Result<ProjectMapping, Error> {
+    tracing::info!("Updating project {} with details {:?}", project, details);
+
+    Err(Error::IncompleteCode(
+        "Update project not implemented".to_string(),
+    ))
 }

--- a/docs/cmdline/portal/Cargo.toml
+++ b/docs/cmdline/portal/Cargo.toml
@@ -17,6 +17,7 @@ built = { version = "0.7", default-features = false, features = ["git2"] }
 anyhow = { version="1.0.95", features = ["backtrace"] }
 templemeads = { path = "../../../templemeads" }
 tokio = { version = "1.43", features = ["full"] }
+tracing = "0.1.41"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/docs/cmdline/portal/src/main.rs
+++ b/docs/cmdline/portal/src/main.rs
@@ -5,6 +5,9 @@ use anyhow::Result;
 
 use templemeads::agent::portal::{process_args, run, Defaults};
 use templemeads::agent::Type as AgentType;
+use templemeads::async_runnable;
+use templemeads::job::{Envelope, Job};
+use templemeads::Error;
 
 use std::path::PathBuf;
 
@@ -34,7 +37,23 @@ async fn main() -> Result<()> {
     };
 
     // run the portal agent
-    run(config).await?;
+    run(config, portal_runner).await?;
 
     Ok(())
+}
+
+async_runnable! {
+    ///
+    /// Runnable function that is called when the portal needs
+    /// to issue a job
+    ///
+    pub async fn portal_runner(envelope: Envelope) -> Result<Job, Error>
+    {
+        let job = envelope.job();
+
+        tracing::error!("Unknown instruction: {:?}", job.instruction());
+        return Err(Error::UnknownInstruction(
+            format!("Unknown instruction: {:?}", job.instruction()).to_string(),
+        ));
+    }
 }

--- a/paddington/src/config.rs
+++ b/paddington/src/config.rs
@@ -626,13 +626,13 @@ impl ServiceConfig {
             return Err(Error::Peer("No zone provided.".to_string()));
         }
 
-        // make sure that zone is [a-zA-Z0-9_]
+        // make sure that zone is [a-zA-Z0-9_<>]
         if !zone
             .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '<' || c == '>')
         {
             return Err(Error::Peer(format!(
-                "Zone '{}' contains invalid characters. It must be alphanumeric or - _",
+                "Zone '{}' contains invalid characters. It must be alphanumeric or - _ < >",
                 zone
             )));
         }

--- a/paddington/src/invite.rs
+++ b/paddington/src/invite.rs
@@ -84,10 +84,10 @@ impl Invite {
         if !self
             .zone
             .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '<' || c == '>')
         {
             return Err(Error::InvalidPeer(format!(
-                "Zone '{}' contains invalid characters. It must be alphanumeric or - _",
+                "Zone '{}' contains invalid characters. It must be alphanumeric or - _ < >",
                 self.zone
             )));
         }

--- a/portal/Cargo.toml
+++ b/portal/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { version="1.0.95", features = ["backtrace"] }
 dirs = "6.0.0"
 templemeads = { path = "../templemeads" }
 tokio = { version = "1.43", features = ["full"] }
+tracing = "0.1.41"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/portal/src/main.rs
+++ b/portal/src/main.rs
@@ -174,9 +174,9 @@ async fn main() -> Result<()> {
                     return Ok(job);
                 }
                 _ => {
-                    if !agent_is_portal {
+                    if !(agent_is_portal || agent_is_bridge) {
                         return Err(Error::InvalidInstruction(
-                            format!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction()),
+                            format!("Invalid instruction: {}. Only portal or bridge agents can send instructions to the portal", job.instruction()),
                         ));
                     }
                 }
@@ -197,9 +197,9 @@ async fn main() -> Result<()> {
                         update_project(me.name(), &project, &details).await?)
                 }
                 _ => {
-                    tracing::error!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction());
+                    tracing::error!("Invalid instruction: {}. Portal agents do not accept this instruction", job.instruction());
                     return Err(Error::InvalidInstruction(
-                        format!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction()),
+                        format!("Invalid instruction: {}. Portal agents do not accept this instruction", job.instruction()),
                     ));
                 }
             }

--- a/slurm/src/main.rs
+++ b/slurm/src/main.rs
@@ -255,7 +255,7 @@ async fn main() -> Result<()> {
                     }
                     _ => {
                         Err(Error::InvalidInstruction(
-                            format!("Invalid instruction: {}. Slurm only supports add_local_user and remove_local_user", job.instruction()),
+                            format!("Invalid instruction: {}. Slurm agents do not support this instruction", job.instruction()),
                         ))
                     }
                 }

--- a/templemeads/src/agent_bridge.rs
+++ b/templemeads/src/agent_bridge.rs
@@ -8,6 +8,7 @@ use crate::bridge_server::{
 };
 use crate::error::Error;
 use crate::handler::{process_message, set_my_service_details};
+use crate::runnable::AsyncRunnable;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -26,7 +27,7 @@ use std::path::PathBuf;
 /// This listens for requests from the bridge http server and
 /// bridges those to the other Agents in the OpenPortal system.
 ///
-pub async fn run(config: Config) -> Result<(), Error> {
+pub async fn run(config: Config, runner: AsyncRunnable) -> Result<(), Error> {
     if config.service.name().is_empty() {
         return Err(Error::Misconfigured("Service name is empty".to_string()));
     }
@@ -38,7 +39,7 @@ pub async fn run(config: Config) -> Result<(), Error> {
     }
 
     // pass the service details onto the handler
-    set_my_service_details(&config.service.name(), &config.agent, None).await?;
+    set_my_service_details(&config.service.name(), &config.agent, Some(runner)).await?;
 
     // spawn the bridge server
     spawn(config.bridge).await?;

--- a/templemeads/src/bridge.rs
+++ b/templemeads/src/bridge.rs
@@ -61,6 +61,8 @@ pub async fn run(command: &str) -> Result<Job, Error> {
                 )));
             }
 
+            tracing::info!("JOB = {:?}", job);
+
             let job = Job::parse(
                 &format!("{}.{} submit {}", my_name, portal.name(), command),
                 true,

--- a/templemeads/src/bridge_server.rs
+++ b/templemeads/src/bridge_server.rs
@@ -420,17 +420,19 @@ async fn fetch_jobs(
 async fn send_result(
     headers: HeaderMap,
     State(state): State<AppState>,
-    Json(payload): Json<Job>,
+    Json(job): Json<Job>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    tracing::debug!("Send result: {:?}", job);
+
     verify_headers(
         &state,
         &headers,
         "post",
         "send_result",
-        Some(serde_json::json!({"job": payload})),
+        Some(serde_json::json!(job)),
     )?;
 
-    tracing::debug!("Sending result: {:?}", payload);
+    tracing::debug!("Sending result: {:?}", job);
 
     // get the BridgeBoard
     let board = get_board().await;
@@ -438,7 +440,7 @@ async fn send_result(
     match board {
         Ok(board) => {
             let mut board = board.write().await;
-            board.update(&payload);
+            board.update(&job);
             Ok(Json(json!({"status": "ok"})))
         }
         Err(e) => {

--- a/templemeads/src/bridge_server.rs
+++ b/templemeads/src/bridge_server.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::bridge::{run as bridge_run, status as bridge_status};
+use crate::bridgestate::get as get_board;
 use crate::error::Error;
 use crate::job::Job;
 
@@ -384,6 +385,70 @@ async fn status(
 }
 
 ///
+/// The 'fetch_jobs' endpoint for the web API. This will return a list
+/// of all of the jobs that OpenPortal has sent to us that we need
+/// to process
+///
+#[tracing::instrument(skip_all)]
+async fn fetch_jobs(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<Job>>, AppError> {
+    verify_headers(&state, &headers, "get", "fetch_jobs", None)?;
+
+    tracing::debug!("Fetching jobs");
+
+    // get the BridgeBoard
+    let board = get_board().await;
+    match board {
+        Ok(board) => {
+            let jobs = board.read().await.unfinished_jobs();
+            Ok(Json(jobs))
+        }
+        Err(e) => {
+            tracing::error!("Error getting jobs: {:?}", e);
+            Err(AppError(e.into(), None))
+        }
+    }
+}
+
+///
+/// The 'send_result' endpoint for the web API. This will send the
+/// result of a job that we need to process back to the OpenPortal system.
+///
+#[tracing::instrument(skip_all)]
+async fn send_result(
+    headers: HeaderMap,
+    State(state): State<AppState>,
+    Json(payload): Json<Job>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    verify_headers(
+        &state,
+        &headers,
+        "post",
+        "send_result",
+        Some(serde_json::json!({"job": payload})),
+    )?;
+
+    tracing::debug!("Sending result: {:?}", payload);
+
+    // get the BridgeBoard
+    let board = get_board().await;
+
+    match board {
+        Ok(board) => {
+            let mut board = board.write().await;
+            board.update(&payload);
+            Ok(Json(json!({"status": "ok"})))
+        }
+        Err(e) => {
+            tracing::error!("Error getting jobs: {:?}", e);
+            Err(AppError(e.into(), None))
+        }
+    }
+}
+
+///
 /// Function spawned to run the API server in a background thread
 ///
 async fn run_server(app: Router, listener: TcpListener) -> Result<()> {
@@ -412,6 +477,8 @@ pub async fn spawn(config: Config) -> Result<(), Error> {
         .route("/health", get(health))
         .route("/run", post(run))
         .route("/status", post(status))
+        .route("/fetch_jobs", get(fetch_jobs))
+        .route("/send_result", post(send_result))
         .with_state(state);
 
     // create a TCP listener on the specified port

--- a/templemeads/src/bridgeboard.rs
+++ b/templemeads/src/bridgeboard.rs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: © 2025 Christopher Woods <Christopher.Woods@bristol.ac.uk>
+// SPDX-License-Identifier: MIT
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use crate::board::{Listener, Waiter};
+use crate::error::Error;
+use crate::job::Job;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct BridgeBoard {
+    jobs: HashMap<Uuid, Job>,
+
+    // do not serialise or clone the waiters
+    #[serde(skip)]
+    waiters: HashMap<Uuid, Vec<Listener>>,
+}
+
+impl Clone for BridgeBoard {
+    /// Clone the board, but do not clone the waiters
+    fn clone(&self) -> Self {
+        Self {
+            jobs: self.jobs.clone(),
+            waiters: HashMap::new(),
+        }
+    }
+}
+
+impl BridgeBoard {
+    pub fn new() -> Self {
+        Self {
+            jobs: HashMap::new(),
+            waiters: HashMap::new(),
+        }
+    }
+
+    ///
+    /// Return a list of all of the unfinished jobs on the board
+    ///
+    pub fn unfinished_jobs(&self) -> Vec<Job> {
+        self.jobs
+            .iter()
+            .filter_map(|(_, job)| {
+                if job.is_finished() {
+                    None
+                } else {
+                    Some(job.clone())
+                }
+            })
+            .collect()
+    }
+
+    ///
+    /// Return a waiter that can be used to receive a job when
+    /// it is either completed or errored. This will block until
+    /// the passed job transitions into one of those states,
+    /// and it will return the new version of the job
+    ///
+    pub fn get_waiter(&mut self, job: &Job) -> Result<Waiter, Error> {
+        // check that we have this job on the board
+        match self.jobs.get(&job.id()) {
+            Some(j) => {
+                // if the job is already in a terminal state then we can return
+                if j.is_finished() {
+                    return Ok(Waiter::finished(j.clone()));
+                }
+            }
+            None => {
+                return Err(Error::NotFound(format!("Job not found: {:?}", job.id())));
+            }
+        }
+
+        let (tx, rx) = oneshot::channel();
+
+        // add the listener to the list of listeners
+        match self.waiters.get_mut(&job.id()) {
+            Some(listeners) => {
+                listeners.push(Listener::new(tx));
+            }
+            None => {
+                self.waiters.insert(job.id(), vec![Listener::new(tx)]);
+            }
+        }
+
+        Ok(Waiter::pending(rx))
+    }
+
+    ///
+    /// Add the passed job to our board - this will return
+    /// a waiter that can be used to wait until the job
+    /// is completed or errored
+    ///
+    /// It is an error to attempt to add a job that is already
+    /// present on the board
+    ///
+    pub fn add(&mut self, job: &Job) -> Result<Waiter, Error> {
+        match self.jobs.get_mut(&job.id()) {
+            Some(j) => {
+                return Err(Error::Duplicate(format!(
+                    "Job already exists on board: {:?}",
+                    j.id()
+                )))
+            }
+            None => {
+                // add the job to the board
+                self.jobs.insert(job.id(), job.clone());
+            }
+        }
+
+        // return a waiter that can be used to wait until the job
+        // is completed or errored
+        self.get_waiter(job)
+    }
+
+    ///
+    /// Update the passed job on our board
+    ///
+    pub fn update(&mut self, job: &Job) {
+        // check that we have this job on the board
+        match self.jobs.get_mut(&job.id()) {
+            Some(j) => {
+                // only update if newer
+                if job.version() > j.version() {
+                    *j = job.clone();
+
+                    // notify any listeners that the job has been updated
+                    if job.is_finished() {
+                        if let Some(listeners) = self.waiters.remove(&job.id()) {
+                            for listener in listeners {
+                                listener.notify(job.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            None => {
+                tracing::warn!("Job not found on board: {:?}", job.id());
+            }
+        }
+    }
+
+    ///
+    /// Remove the passed job from our board
+    /// If the job doesn't exist then we fail silently
+    ///
+    /// This returns whether or not the board has changed
+    /// (i.e. whether the job was on the board)
+    ///
+    pub fn remove(&mut self, job: &Job) -> Result<bool, Error> {
+        // if we have any waiters for this job then notify them with an error
+        if let Some(listeners) = self.waiters.remove(&job.id()) {
+            let mut notify_job = job.clone();
+
+            if !notify_job.is_finished() {
+                notify_job = notify_job.errored("Job removed from board")?;
+            }
+
+            for listener in listeners {
+                listener.notify(notify_job.clone());
+            }
+        }
+
+        let removed = self.jobs.remove(&job.id()).is_some();
+
+        Ok(removed)
+    }
+
+    ///
+    /// Get the job with the passed id
+    /// If the job doesn't exist then we return an error
+    ///
+    pub fn get(&self, id: &Uuid) -> Result<Job, Error> {
+        match self.jobs.get(id) {
+            Some(j) => Ok(j.clone()),
+            None => Err(Error::NotFound(format!("Job not found: {:?}", id))),
+        }
+    }
+
+    ///
+    /// Return whether or not this board would be changed by the
+    /// passed job
+    ///
+    pub fn would_be_changed_by(&self, job: &Job) -> bool {
+        if job.is_expired() {
+            return false;
+        }
+
+        match self.jobs.get(&job.id()) {
+            Some(j) => {
+                // only update if newer
+                job.version() > j.version()
+            }
+            None => true,
+        }
+    }
+
+    ///
+    /// Remove all expired jobs from the board
+    ///
+    pub fn remove_expired_jobs(&mut self) {
+        let expired_jobs: Vec<Uuid> = self
+            .jobs
+            .iter()
+            .filter_map(|(id, job)| {
+                if job.is_expired() {
+                    // remove any listeners for this job
+                    if let Some(listeners) = self.waiters.remove(id) {
+                        for listener in listeners {
+                            listener.notify(job.clone());
+                        }
+                    }
+
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for job_id in expired_jobs.iter() {
+            let _ = self.jobs.remove(job_id);
+        }
+    }
+}

--- a/templemeads/src/bridgestate.rs
+++ b/templemeads/src/bridgestate.rs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2025 Christopher Woods <Christopher.Woods@bristol.ac.uk>
+// SPDX-License-Identifier: MIT
+
+use crate::bridgeboard::BridgeBoard;
+use crate::error::Error;
+
+use anyhow::Result;
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+struct State {
+    board: Arc<RwLock<BridgeBoard>>,
+}
+
+static STATE: Lazy<RwLock<State>> = Lazy::new(|| RwLock::new(State::new()));
+
+impl State {
+    fn new() -> Self {
+        start_cleaner();
+
+        Self {
+            board: Arc::new(RwLock::new(BridgeBoard::new())),
+        }
+    }
+}
+
+///
+/// Return the board for the bridge
+///
+pub async fn get() -> Result<Arc<RwLock<BridgeBoard>>, Error> {
+    let state = STATE.read().await;
+    Ok(state.board.clone())
+}
+
+///
+/// Function called in a tokio task to clean up the board
+///
+fn start_cleaner() {
+    tokio::spawn(async {
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+            clean_board().await;
+        }
+    });
+}
+
+///
+/// Call this function to clean up the expired jobs from the board
+///
+async fn clean_board() {
+    let state = match get().await {
+        Ok(state) => state,
+        Err(e) => {
+            tracing::error!("Error getting state: {}", e);
+            return;
+        }
+    };
+
+    state.write().await.remove_expired_jobs();
+}

--- a/templemeads/src/destination.rs
+++ b/templemeads/src/destination.rs
@@ -76,6 +76,11 @@ impl Destination {
         self.agents.first().unwrap_or(&"".to_string()).clone()
     }
 
+    pub fn second(&self) -> String {
+        // there are always at least two agents in a destination
+        self.agents.get(1).unwrap_or(&"".to_string()).clone()
+    }
+
     pub fn last(&self) -> String {
         // there are always at least two agents in a destination
         self.agents.last().unwrap_or(&"".to_string()).clone()

--- a/templemeads/src/grammar.rs
+++ b/templemeads/src/grammar.rs
@@ -1210,6 +1210,12 @@ impl ProjectClass {
     }
 }
 
+impl NamedType for ProjectClass {
+    fn type_name() -> &'static str {
+        "ProjectClass"
+    }
+}
+
 impl std::fmt::Display for ProjectClass {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
@@ -1265,6 +1271,12 @@ pub struct ProjectDetails {
 
     /// The number of credit (hours) allocated to the project
     credit: Option<Usage>,
+}
+
+impl NamedType for ProjectDetails {
+    fn type_name() -> &'static str {
+        "ProjectDetails"
+    }
 }
 
 impl ProjectDetails {
@@ -2105,6 +2117,90 @@ impl Instruction {
                 tracing::error!("Invalid instruction: {}", s);
                 Err(Error::Parse(format!("Invalid instruction: {}", s)))
             }
+        }
+    }
+
+    pub fn command(&self) -> String {
+        match self {
+            Instruction::Submit(_, _) => "submit".to_string(),
+            Instruction::CreateProject(_, _) => "create_project".to_string(),
+            Instruction::UpdateProject(_, _) => "update_project".to_string(),
+            Instruction::GetProjects(_) => "get_projects".to_string(),
+            Instruction::AddProject(_) => "add_project".to_string(),
+            Instruction::RemoveProject(_) => "remove_project".to_string(),
+            Instruction::GetUsers(_) => "get_users".to_string(),
+            Instruction::AddUser(_) => "add_user".to_string(),
+            Instruction::RemoveUser(_) => "remove_user".to_string(),
+            Instruction::GetUserMapping(_) => "get_user_mapping".to_string(),
+            Instruction::GetProjectMapping(_) => "get_project_mapping".to_string(),
+            Instruction::GetHomeDir(_) => "get_home_dir".to_string(),
+            Instruction::GetProjectDirs(_) => "get_project_dirs".to_string(),
+            Instruction::AddLocalUser(_) => "add_local_user".to_string(),
+            Instruction::RemoveLocalUser(_) => "remove_local_user".to_string(),
+            Instruction::AddLocalProject(_) => "add_local_project".to_string(),
+            Instruction::RemoveLocalProject(_) => "remove_local_project".to_string(),
+            Instruction::GetLocalUsageReport(_, _) => "get_local_usage_report".to_string(),
+            Instruction::GetLocalLimit(_) => "get_local_limit".to_string(),
+            Instruction::SetLocalLimit(_, _) => "set_local_limit".to_string(),
+            Instruction::GetLocalHomeDir(_) => "get_local_home_dir".to_string(),
+            Instruction::GetLocalProjectDirs(_) => "get_local_project_dirs".to_string(),
+            Instruction::UpdateHomeDir(_, _) => "update_homedir".to_string(),
+            Instruction::GetUsageReport(_, _) => "get_usage_report".to_string(),
+            Instruction::GetUsageReports(_, _) => "get_usage_reports".to_string(),
+            Instruction::SetLimit(_, _) => "set_limit".to_string(),
+            Instruction::GetLimit(_) => "get_limit".to_string(),
+            Instruction::IsProtectedUser(_) => "is_protected_user".to_string(),
+        }
+    }
+
+    pub fn arguments(&self) -> Vec<String> {
+        match self {
+            Instruction::Submit(destination, command) => {
+                vec![destination.to_string(), command.to_string()]
+            }
+            Instruction::CreateProject(project, details) => {
+                vec![project.to_string(), details.to_string()]
+            }
+            Instruction::UpdateProject(project, details) => {
+                vec![project.to_string(), details.to_string()]
+            }
+            Instruction::GetProjects(portal) => vec![portal.to_string()],
+            Instruction::AddProject(project) => vec![project.to_string()],
+            Instruction::RemoveProject(project) => vec![project.to_string()],
+            Instruction::GetUsers(project) => vec![project.to_string()],
+            Instruction::AddUser(user) => vec![user.to_string()],
+            Instruction::RemoveUser(user) => vec![user.to_string()],
+            Instruction::GetUserMapping(user) => vec![user.to_string()],
+            Instruction::GetProjectMapping(project) => vec![project.to_string()],
+            Instruction::GetHomeDir(user) => vec![user.to_string()],
+            Instruction::GetProjectDirs(project) => vec![project.to_string()],
+            Instruction::AddLocalUser(mapping) => vec![mapping.to_string()],
+            Instruction::RemoveLocalUser(mapping) => vec![mapping.to_string()],
+            Instruction::AddLocalProject(mapping) => vec![mapping.to_string()],
+            Instruction::RemoveLocalProject(mapping) => vec![mapping.to_string()],
+            Instruction::GetLocalUsageReport(mapping, date_range) => {
+                vec![mapping.to_string(), date_range.to_string()]
+            }
+            Instruction::GetLocalLimit(mapping) => vec![mapping.to_string()],
+            Instruction::SetLocalLimit(mapping, usage) => {
+                vec![mapping.to_string(), usage.seconds().to_string()]
+            }
+            Instruction::GetLocalHomeDir(mapping) => vec![mapping.to_string()],
+            Instruction::GetLocalProjectDirs(mapping) => vec![mapping.to_string()],
+            Instruction::UpdateHomeDir(user, homedir) => {
+                vec![user.to_string(), homedir.clone()]
+            }
+            Instruction::GetUsageReport(project, date_range) => {
+                vec![project.to_string(), date_range.to_string()]
+            }
+            Instruction::GetUsageReports(portal, date_range) => {
+                vec![portal.to_string(), date_range.to_string()]
+            }
+            Instruction::SetLimit(project, usage) => {
+                vec![project.to_string(), usage.seconds().to_string()]
+            }
+            Instruction::GetLimit(project) => vec![project.to_string()],
+            Instruction::IsProtectedUser(user) => vec![user.to_string()],
         }
     }
 }

--- a/templemeads/src/grammar.rs
+++ b/templemeads/src/grammar.rs
@@ -1297,6 +1297,42 @@ impl ProjectDetails {
     pub fn to_json(&self) -> String {
         serde_json::to_string(self).unwrap_or_default()
     }
+
+    pub fn name(&self) -> Option<String> {
+        self.name.clone()
+    }
+
+    pub fn class(&self) -> Option<ProjectClass> {
+        self.class.clone()
+    }
+
+    pub fn description(&self) -> Option<String> {
+        self.description.clone()
+    }
+
+    pub fn leads(&self) -> Option<Vec<String>> {
+        self.leads.clone()
+    }
+
+    pub fn co_leads(&self) -> Option<Vec<String>> {
+        self.co_leads.clone()
+    }
+
+    pub fn members(&self) -> Option<Vec<String>> {
+        self.members.clone()
+    }
+
+    pub fn start_date(&self) -> Option<Date> {
+        self.start_date.clone()
+    }
+
+    pub fn end_date(&self) -> Option<Date> {
+        self.end_date.clone()
+    }
+
+    pub fn credit(&self) -> Option<Usage> {
+        self.credit
+    }
 }
 
 impl std::fmt::Display for ProjectDetails {

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -147,6 +147,8 @@ impl Command {
             }
 
             let project = match instruction.clone() {
+                Instruction::CreateProject(project, _) => Some(project),
+                Instruction::UpdateProject(project, _) => Some(project),
                 Instruction::AddProject(project) => Some(project),
                 Instruction::AddLocalProject(project) => Some(project.project().clone()),
                 Instruction::RemoveLocalProject(project) => Some(project.project().clone()),

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -312,6 +312,14 @@ impl Job {
         })
     }
 
+    pub fn to_json(&self) -> Result<String, Error> {
+        serde_json::to_string(self).map_err(Error::SerdeJson)
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, Error> {
+        serde_json::from_str(json).map_err(Error::SerdeJson)
+    }
+
     pub fn id(&self) -> Uuid {
         self.id
     }

--- a/templemeads/src/lib.rs
+++ b/templemeads/src/lib.rs
@@ -6,6 +6,8 @@ mod account;
 mod agent_bridge;
 mod agent_core;
 mod bridge_server;
+mod bridgeboard;
+mod bridgestate;
 mod control_message;
 mod custom;
 mod error;
@@ -33,4 +35,5 @@ pub mod usagereport;
 
 pub mod server {
     pub use crate::bridge_server::sign_api_call;
+    pub use crate::bridgestate::get as get_board;
 }

--- a/templemeads/src/portal.rs
+++ b/templemeads/src/portal.rs
@@ -1,213 +1,30 @@
 // SPDX-FileCopyrightText: © 2024 Christopher Woods <Christopher.Woods@bristol.ac.uk>
 // SPDX-License-Identifier: MIT
 
-use crate::agent;
-use crate::agent::Type::{Bridge, Portal};
+use crate::agent::Type as AgentType;
 use crate::agent_core::Config;
 use crate::error::Error;
-use crate::grammar::Instruction::{CreateProject, Submit, UpdateProject};
-use crate::job::{Envelope, Job};
 
 use crate::handler::{process_message, set_my_service_details};
+use crate::runnable::AsyncRunnable;
 use anyhow::Result;
-
-///
-/// Return the zone that should be used for a portal to portal
-/// connection where the sender has the ability to send jobs
-/// to the recipient (but the recipient cannot send jobs to the sender)
-///
-fn portal_to_portal_zone(sender: &agent::Peer, recipient: &agent::Peer) -> String {
-    format!("{}>{}", sender.name(), recipient.name())
-}
-
-///
-/// Return whether or not the sender has permission to send jobs
-/// to the recipient, assuming they are both portals
-///
-fn portal_to_portal_allowed(sender: &agent::Peer, recipient: &agent::Peer) -> bool {
-    (sender.zone() == recipient.zone())
-        && (sender.zone() == portal_to_portal_zone(sender, recipient))
-}
-
-crate::async_runnable! {
-///
-/// Runnable function that will be called when a job is received
-/// by the portal. This creates a firewall between the agents
-/// south of the portal (which e.g. actually create accounts etc)
-/// the agents north of the portal (which e.g. create or query
-/// allocations) and the bridge agent to the east/west of the portal,
-/// which connects to the graphical portal user interface.
-///
-pub async fn portal_runner(envelope: Envelope) -> Result<Job, Error>
-{
-    let mut job = envelope.job();
-
-    let mut agent_is_bridge = false;
-    let mut agent_is_portal = false;
-
-    // Get information about the agent that sent this job
-    // The only agents that can send jobs to a portal are
-    // bridge agents, and other portal agents that have
-    // expressly be configured to be given permission.
-    // This permission is based on the zone of the portal to portal
-    // connection
-    match agent::agent_type(&envelope.sender()).await {
-        Some(Bridge) => {
-            agent_is_bridge = true;
-        }
-        Some(Portal) => {
-            if !portal_to_portal_allowed(&envelope.sender(), &envelope.recipient()) {
-                return Err(Error::InvalidInstruction(
-                    format!("Invalid instruction: {}. Portal {} is not allowed to send jobs to portal {}", job.instruction(), envelope.sender(), envelope.recipient()),
-                ));
-            }
-            agent_is_portal = true;
-        }
-        _ => {
-            return Err(Error::InvalidInstruction(
-                format!("Invalid instruction: {}. Only bridge agents can submit instructions to the portal", job.instruction()),
-            ));
-        }
-    }
-
-    let sender = envelope.sender();
-
-    // match instructions that can only be sent by bridge agents
-    match job.instruction() {
-        Submit(destination, instruction) => {
-            if !agent_is_bridge {
-                return Err(Error::InvalidInstruction(
-                    format!("Invalid instruction: {}. Only bridge agents can submit instructions to the portal", job.instruction()),
-                ));
-            }
-
-            // This is a job that should have been received from
-            // the bridge, and which is to be interpreted and passed
-            // south-bound to the agents for processing
-            tracing::debug!("{} : {}", destination, instruction);
-            tracing::debug!("This was from {:?}", envelope);
-
-            if destination.agents().len() < 2 {
-                tracing::error!("Invalid instruction: {}. Destination must have at least two agents", job.instruction());
-                return Err(Error::InvalidInstruction(
-                    format!("Invalid instruction: {}. Destination must have at least two agents", job.instruction()),
-                ));
-            }
-
-            // the first agent in the destination is the agent should be this portal
-            let first_agent = destination.agents()[0].clone();
-
-            if first_agent != envelope.recipient().name() {
-                tracing::error!("Invalid instruction: {}. First agent in destination should be this portal ({})", job.instruction(), envelope.recipient().name());
-                return Err(Error::InvalidInstruction(
-                    format!("Invalid instruction: {}. First agent in destination should be this portal ({})",
-                                job.instruction(),
-                                envelope.recipient().name())
-                ));
-            }
-
-            // who is next in line to receive this job? - find it, and its zone
-            let next_agent = agent::find(&destination.agents()[1], 5).await.ok_or_else(|| {
-                tracing::error!("Invalid instruction: {}. Cannot find next agent in destination {}", job.instruction(), destination);
-                Error::InvalidInstruction(
-                    format!("Invalid instruction: {}. Cannot find next agent in destination {}",
-                            job.instruction(), destination),
-                )
-            })?;
-
-            // create the job and send it to the board for the next agent
-            let southbound_job = Job::parse(&format!("{} {}", destination, instruction), true)?.put(&next_agent).await?;
-
-            job = job.running(Some("Job registered - processing...".to_string()))?;
-            job = job.update(&sender).await?;
-
-            // Wait for the submitted job to complete
-            let southbound_job = southbound_job.wait().await?;
-
-            if southbound_job.is_expired() {
-                tracing::error!("{} : {} : Error - job expired!", destination, instruction);
-                job = job.errored("ExpirationError{{}}")?;
-             } else if (southbound_job.is_error()) {
-                if let Some(message) = southbound_job.error_message() {
-                    tracing::error!("{} : {} : Error - {}", destination, instruction, message);
-                    job = job.errored(&format!("RuntimeError{{{}}}", message))?;
-                }
-                else {
-                    tracing::error!("{} : {} : Error - unknown error", destination, instruction);
-                    job = job.errored("UnknownError{{}}")?;
-                }
-             }
-             else {
-                tracing::info!("{} : {} : Success", destination, instruction);
-                job = job.copy_result_from(&southbound_job)?;
-            }
-
-            return Ok(job);
-        }
-        _ => {
-            if !agent_is_portal {
-                return Err(Error::InvalidInstruction(
-                    format!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction()),
-                ));
-            }
-        }
-    }
-
-    // match instructions that can be sent by portal agents
-    match job.instruction() {
-        CreateProject(project, details) => {
-            tracing::debug!("{} : {}", project, details);
-            tracing::debug!("This was from {:?}", envelope);
-
-            // do the work to create the project
-            tracing::info!("Creating project {} with details {}", project, details);
-
-            job = job.completed("Project created".to_string())?;
-
-            return Ok(job);
-        }
-        UpdateProject(project, details) => {
-            tracing::debug!("{} : {}", project, details);
-            tracing::debug!("This was from {:?}", envelope);
-
-            // do the work to update the project
-            tracing::info!("Updating project {} with details {}", project, details);
-
-            job = job.completed("Project updated".to_string())?;
-
-            return Ok(job);
-        }
-        _ => {
-            tracing::error!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction());
-            return Err(Error::InvalidInstruction(
-                format!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction()),
-            ));
-        }
-    }
-}
-}
 
 ///
 /// Run the agent service
 ///
-pub async fn run(config: Config) -> Result<(), Error> {
+pub async fn run(config: Config, runner: AsyncRunnable) -> Result<(), Error> {
     if config.service().name().is_empty() {
         return Err(Error::Misconfigured("Service name is empty".to_string()));
     }
 
-    if config.agent() != Portal {
+    if config.agent() != AgentType::Portal {
         return Err(Error::Misconfigured(
             "Service agent is not a Portal".to_string(),
         ));
     }
 
     // pass the service details onto the handler
-    set_my_service_details(
-        &config.service().name(),
-        &config.agent(),
-        Some(portal_runner),
-    )
-    .await?;
+    set_my_service_details(&config.service().name(), &config.agent(), Some(runner)).await?;
 
     // run the Provider OpenPortal agent
     paddington::set_handler(process_message).await?;

--- a/templemeads/src/portal.rs
+++ b/templemeads/src/portal.rs
@@ -26,7 +26,7 @@ pub async fn run(config: Config, runner: AsyncRunnable) -> Result<(), Error> {
     // pass the service details onto the handler
     set_my_service_details(&config.service().name(), &config.agent(), Some(runner)).await?;
 
-    // run the Provider OpenPortal agent
+    // run the Portal OpenPortal agent
     paddington::set_handler(process_message).await?;
     paddington::run(config.service()).await?;
 

--- a/templemeads/src/portal.rs
+++ b/templemeads/src/portal.rs
@@ -5,112 +5,186 @@ use crate::agent;
 use crate::agent::Type::{Bridge, Portal};
 use crate::agent_core::Config;
 use crate::error::Error;
-use crate::grammar::Instruction::Submit;
+use crate::grammar::Instruction::{CreateProject, Submit, UpdateProject};
 use crate::job::{Envelope, Job};
 
 use crate::handler::{process_message, set_my_service_details};
 use anyhow::Result;
 
-crate::async_runnable! {
-    ///
-    /// Runnable function that will be called when a job is received
-    /// by the portal. This creates a firewall between the agents
-    /// south of the portal (which e.g. actually create accounts etc)
-    /// the agents north of the portal (which e.g. create or query
-    /// allocations) and the bridge agent to the east/west of the portal,
-    /// which connects to the graphical portal user interface.
-    ///
-    pub async fn portal_runner(envelope: Envelope) -> Result<Job, Error>
-    {
-        let mut job = envelope.job();
+///
+/// Return the zone that should be used for a portal to portal
+/// connection where the sender has the ability to send jobs
+/// to the recipient (but the recipient cannot send jobs to the sender)
+///
+fn portal_to_portal_zone(sender: &agent::Peer, recipient: &agent::Peer) -> String {
+    format!("{}>{}", sender.name(), recipient.name())
+}
 
-        // get information about the agent that sent this job
-        // - double check that they are a bridge agent
-        // (these are the only agent type that should be submitting
-        //  jobs to the portal)
-        match agent::agent_type(&envelope.sender()).await {
-            Some(Bridge) => {}
-            _ => {
+///
+/// Return whether or not the sender has permission to send jobs
+/// to the recipient, assuming they are both portals
+///
+fn portal_to_portal_allowed(sender: &agent::Peer, recipient: &agent::Peer) -> bool {
+    (sender.zone() == recipient.zone())
+        && (sender.zone() == portal_to_portal_zone(sender, recipient))
+}
+
+crate::async_runnable! {
+///
+/// Runnable function that will be called when a job is received
+/// by the portal. This creates a firewall between the agents
+/// south of the portal (which e.g. actually create accounts etc)
+/// the agents north of the portal (which e.g. create or query
+/// allocations) and the bridge agent to the east/west of the portal,
+/// which connects to the graphical portal user interface.
+///
+pub async fn portal_runner(envelope: Envelope) -> Result<Job, Error>
+{
+    let mut job = envelope.job();
+
+    let mut agent_is_bridge = false;
+    let mut agent_is_portal = false;
+
+    // Get information about the agent that sent this job
+    // The only agents that can send jobs to a portal are
+    // bridge agents, and other portal agents that have
+    // expressly be configured to be given permission.
+    // This permission is based on the zone of the portal to portal
+    // connection
+    match agent::agent_type(&envelope.sender()).await {
+        Some(Bridge) => {
+            agent_is_bridge = true;
+        }
+        Some(Portal) => {
+            if !portal_to_portal_allowed(&envelope.sender(), &envelope.recipient()) {
+                return Err(Error::InvalidInstruction(
+                    format!("Invalid instruction: {}. Portal {} is not allowed to send jobs to portal {}", job.instruction(), envelope.sender(), envelope.recipient()),
+                ));
+            }
+            agent_is_portal = true;
+        }
+        _ => {
+            return Err(Error::InvalidInstruction(
+                format!("Invalid instruction: {}. Only bridge agents can submit instructions to the portal", job.instruction()),
+            ));
+        }
+    }
+
+    let sender = envelope.sender();
+
+    // match instructions that can only be sent by bridge agents
+    match job.instruction() {
+        Submit(destination, instruction) => {
+            if !agent_is_bridge {
                 return Err(Error::InvalidInstruction(
                     format!("Invalid instruction: {}. Only bridge agents can submit instructions to the portal", job.instruction()),
                 ));
             }
-        }
 
-        let sender = envelope.sender();
+            // This is a job that should have been received from
+            // the bridge, and which is to be interpreted and passed
+            // south-bound to the agents for processing
+            tracing::debug!("{} : {}", destination, instruction);
+            tracing::debug!("This was from {:?}", envelope);
 
-        match job.instruction() {
-            Submit(destination, instruction) => {
-                // This is a job that should have been received from
-                // the bridge, and which is to be interpreted and passed
-                // south-bound to the agents for processing
-                tracing::debug!("{} : {}", destination, instruction);
-                tracing::debug!("This was from {:?}", envelope);
-
-                if destination.agents().len() < 2 {
-                    tracing::error!("Invalid instruction: {}. Destination must have at least two agents", job.instruction());
-                    return Err(Error::InvalidInstruction(
-                        format!("Invalid instruction: {}. Destination must have at least two agents", job.instruction()),
-                    ));
-                }
-
-                // the first agent in the destination is the agent should be this portal
-                let first_agent = destination.agents()[0].clone();
-
-                if first_agent != envelope.recipient().name() {
-                    tracing::error!("Invalid instruction: {}. First agent in destination should be this portal ({})", job.instruction(), envelope.recipient().name());
-                    return Err(Error::InvalidInstruction(
-                        format!("Invalid instruction: {}. First agent in destination should be this portal ({})",
-                                    job.instruction(),
-                                    envelope.recipient().name())
-                    ));
-                }
-
-                // who is next in line to receive this job? - find it, and its zone
-                let next_agent = agent::find(&destination.agents()[1], 5).await.ok_or_else(|| {
-                    tracing::error!("Invalid instruction: {}. Cannot find next agent in destination {}", job.instruction(), destination);
-                    Error::InvalidInstruction(
-                        format!("Invalid instruction: {}. Cannot find next agent in destination {}",
-                                job.instruction(), destination),
-                    )
-                })?;
-
-                // create the job and send it to the board for the next agent
-                let southbound_job = Job::parse(&format!("{} {}", destination, instruction), true)?.put(&next_agent).await?;
-
-                job = job.running(Some("Job registered - processing...".to_string()))?;
-                job = job.update(&sender).await?;
-
-                // Wait for the submitted job to complete
-                let southbound_job = southbound_job.wait().await?;
-
-                if southbound_job.is_expired() {
-                    tracing::error!("{} : {} : Error - job expired!", destination, instruction);
-                    job = job.errored("ExpirationError{{}}")?;
-                 } else if (southbound_job.is_error()) {
-                    if let Some(message) = southbound_job.error_message() {
-                        tracing::error!("{} : {} : Error - {}", destination, instruction, message);
-                        job = job.errored(&format!("RuntimeError{{{}}}", message))?;
-                    }
-                    else {
-                        tracing::error!("{} : {} : Error - unknown error", destination, instruction);
-                        job = job.errored("UnknownError{{}}")?;
-                    }
-                 }
-                 else {
-                    tracing::info!("{} : {} : Success", destination, instruction);
-                    job = job.copy_result_from(&southbound_job)?;
-                }
-
-                Ok(job)
+            if destination.agents().len() < 2 {
+                tracing::error!("Invalid instruction: {}. Destination must have at least two agents", job.instruction());
+                return Err(Error::InvalidInstruction(
+                    format!("Invalid instruction: {}. Destination must have at least two agents", job.instruction()),
+                ));
             }
-            _ => {
-                Err(Error::InvalidInstruction(
-                    format!("Invalid instruction: {}. Portals only support 'submit'", job.instruction()),
-                ))
+
+            // the first agent in the destination is the agent should be this portal
+            let first_agent = destination.agents()[0].clone();
+
+            if first_agent != envelope.recipient().name() {
+                tracing::error!("Invalid instruction: {}. First agent in destination should be this portal ({})", job.instruction(), envelope.recipient().name());
+                return Err(Error::InvalidInstruction(
+                    format!("Invalid instruction: {}. First agent in destination should be this portal ({})",
+                                job.instruction(),
+                                envelope.recipient().name())
+                ));
+            }
+
+            // who is next in line to receive this job? - find it, and its zone
+            let next_agent = agent::find(&destination.agents()[1], 5).await.ok_or_else(|| {
+                tracing::error!("Invalid instruction: {}. Cannot find next agent in destination {}", job.instruction(), destination);
+                Error::InvalidInstruction(
+                    format!("Invalid instruction: {}. Cannot find next agent in destination {}",
+                            job.instruction(), destination),
+                )
+            })?;
+
+            // create the job and send it to the board for the next agent
+            let southbound_job = Job::parse(&format!("{} {}", destination, instruction), true)?.put(&next_agent).await?;
+
+            job = job.running(Some("Job registered - processing...".to_string()))?;
+            job = job.update(&sender).await?;
+
+            // Wait for the submitted job to complete
+            let southbound_job = southbound_job.wait().await?;
+
+            if southbound_job.is_expired() {
+                tracing::error!("{} : {} : Error - job expired!", destination, instruction);
+                job = job.errored("ExpirationError{{}}")?;
+             } else if (southbound_job.is_error()) {
+                if let Some(message) = southbound_job.error_message() {
+                    tracing::error!("{} : {} : Error - {}", destination, instruction, message);
+                    job = job.errored(&format!("RuntimeError{{{}}}", message))?;
+                }
+                else {
+                    tracing::error!("{} : {} : Error - unknown error", destination, instruction);
+                    job = job.errored("UnknownError{{}}")?;
+                }
+             }
+             else {
+                tracing::info!("{} : {} : Success", destination, instruction);
+                job = job.copy_result_from(&southbound_job)?;
+            }
+
+            return Ok(job);
+        }
+        _ => {
+            if !agent_is_portal {
+                return Err(Error::InvalidInstruction(
+                    format!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction()),
+                ));
             }
         }
     }
+
+    // match instructions that can be sent by portal agents
+    match job.instruction() {
+        CreateProject(project, details) => {
+            tracing::debug!("{} : {}", project, details);
+            tracing::debug!("This was from {:?}", envelope);
+
+            // do the work to create the project
+            tracing::info!("Creating project {} with details {}", project, details);
+
+            job = job.completed("Project created".to_string())?;
+
+            return Ok(job);
+        }
+        UpdateProject(project, details) => {
+            tracing::debug!("{} : {}", project, details);
+            tracing::debug!("This was from {:?}", envelope);
+
+            // do the work to update the project
+            tracing::info!("Updating project {} with details {}", project, details);
+
+            job = job.completed("Project updated".to_string())?;
+
+            return Ok(job);
+        }
+        _ => {
+            tracing::error!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction());
+            return Err(Error::InvalidInstruction(
+                format!("Invalid instruction: {}. Only portal agents can send instructions to the portal", job.instruction()),
+            ));
+        }
+    }
+}
 }
 
 ///


### PR DESCRIPTION
### Added
- Added new commands to support the creation and updating of projects in
  attached portals. These are `create_project`, `update_project`, and
  `get_project`, all of which use new `ProjectDetails` and `ProjectClass`
  objects to describe the project in more detail.

- Added the ability for portals to send commands to other portals. This allows
  a "higher level" portal to send `create_project` and `update_project`
  commands to a "lower level" portal, which will create the project there.
  Then, other commands (such as `get_usage_report` and `get_project`)
  can be used to query and get data about projects owned by the
  "higher level" portal.

- Added the ability for the bridge agent connected to a portal to also
  send `create_project`, `update_project` and `get_project` commands
  to its attached portal. This allows the Python interface created
  via OpenPortal to be used to create and manage projects directly
  in the portal, without needing to use the web portal's own API.
  This should simplify automation of project creation and management.

- Added a bridge-side job board, so that jobs sent from a portal
  to a bridge (so that the attached web portal can access and process
  them) can now be accessed from Python, processed, and then the
  results sent back to the portal. The web-portal, via a Python interface,
  can now call `fetch_job`, `fetch_jobs` and `send_result` to
  get any jobs sent to the bridge, and send back the results.

- Added more functions to the Python API and made it easier to use.
  Can now properly use the `Job` class from Python, have more
  detail about the job status, and the `Instruction` class now
  has functions to get the job command and arguments. This should
  make it much easier to interface web-portals with OpenPortal
  via the Python API, and to write Python scripts that automate
  project creation and management.

### Fixed
- Fixed a bug where `job.wait()` could wake up even if the job
  has not yet completed. This left the `result` as empty,
  which was surprising behaviour. Now, `job.wait()` will
  keep waiting until the job has completed - with a safeguard
  that if it re-awakens more than 10 times it will return
  an error. This should prevent an infinite loop. This fixes
  issue #12.

- Fixed a bug where FreeIPA was allowed to create user accounts
  when the home directory was not set. Now, this will raise an
  error. This fixes issue #13.