### PR TITLE
Feature robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 ### Added
+- Added automatic de-duplication of jobs. Now, if the board detects
+  that a job is added that is the same as one that is already being
+  processed, it will automatically mark the new job as a "duplicate",
+  and will not process it. Instead, it will copy the result from the
+  already-running job and return that result once it is ready. In this
+  way, we prevent job storms if a caller continually re-submits the
+  same job without waiting for the result. Duplicate jobs are caught
+  in the communication chain, so will not be sent on to downstream
+  peers. This makes the system more responsive and robust, as
+  now only new jobs are processed downstream, with duplicates
+  filtered out at a high level.
+
+- Added passing of the job expiry time to the functions called by
+  the slurm and freeipa agents. Now, these agents will abort any
+  functions calls that take too long and that whose results would
+  be ignored anyway as the calling job had expired. This prevents
+  resource starvation and denial of service / deadlocks caused
+  by floods of long-running jobs blocking the system, and causing
+  all new jobs to timeout or run slowly.
+
+- Added a semaphore to the function calls of the slurm and freeipa
+  agents. This semaphore ensures that only 10 jobs can be processed
+  at the same time. This reduces contention pressure on the
+  (serialised) access to the freeipa / slurm REST APIs, or to
+  running saact/mgr commands. This prevents a deadlock situation
+  where a single function calls the API or runs the command
+  one after the other, but gets blocked by a storm of new
+  jobs that hold that resource in the first call to the API
+  or command. In this case, all of the jobs would be blocking
+  each other on the first call, preventing any from making
+  subsequent calls, and thus the jobs expire (but the function
+  call would keep going). Now, only 10 function calls can be
+  made in parallel, which will reduce contention and ensure
+  that they can complete before job expiry. This, combined with
+  checking the job expiry time, should prevent flooding
+  of the system, and creating of long chains / queues of jobs
+  that never complete.
+
+- Added timeouts to REST API calls and for running external
+  commands. These timeouts (60 seconds) ensure that if any
+  command or REST call takes too long, then they will be terminated
+  and an error returned. This is important, as calling a REST
+  API or running a command is serialised (held behind a mutex)
+  to ensure that OpenPortal doesn't flood downstream services
+  (OpenPortal only makes one FreeIPA rest call, or one SLURM
+  call at a time). Previously, a failure of, e.g. FreeIPA,
+  could cause the freeipa agent to hang indefinitely, as the
+  REST API call would never return. Now, if the call takes
+  longer than 60 seconds, it will be aborted, and an error
+  returned. This, combined with all of the changes described
+  above should make the whole OpenPortal more robust
+  and resilient to errors and job storms.
+
 - Added a "signal_url" that can be called by the bridge to signal
   the connected web-portal that a new job has been submitted and
   is awaiting processing. The Job ID is submitted as a query

--- a/bridge/src/main.rs
+++ b/bridge/src/main.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context, Result};
 use reqwest::Client;
+use std::time::Duration;
 use url::Url;
 
 use templemeads::agent;
@@ -297,6 +298,7 @@ pub async fn signal_web_portal(signal_url: &Option<Url>, job: &Job) -> Result<()
 
         let client = Client::builder()
             .danger_accept_invalid_certs(should_allow_invalid_certs())
+            .timeout(Duration::from_secs(60))
             .build()
             .with_context(|| {
                 format!(

--- a/freeipa/src/cache.rs
+++ b/freeipa/src/cache.rs
@@ -361,7 +361,12 @@ pub async fn remove_existing_user(user: &IPAUser) -> Result<(), Error> {
 /// if it doesn't exist
 ///
 pub async fn get_group(group: &ProjectIdentifier) -> Result<Option<IPAGroup>, Error> {
+    tracing::debug!("Getting group {} from cache - awaiting lock...", group);
     let cache = CACHE.read().await;
+    tracing::debug!(
+        "Lock obtained. Cache contains {} groups",
+        cache.groups.len()
+    );
     Ok(cache.groups.get(group).cloned())
 }
 

--- a/freeipa/src/freeipa.rs
+++ b/freeipa/src/freeipa.rs
@@ -9,6 +9,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 use templemeads::grammar::{
     PortalIdentifier, ProjectIdentifier, ProjectMapping, UserIdentifier, UserMapping,
 };
@@ -67,9 +68,12 @@ where
         "id": id,
     });
 
+    // no query should take longer than 60 seconds
+    // Use a timeout to prevent deadlocks from failed servers
     let client = Client::builder()
         .cookie_provider(Arc::clone(&auth.jar))
         .danger_accept_invalid_certs(should_allow_invalid_certs())
+        .timeout(Duration::from_secs(60))
         .build()
         .context("Could not build client")?;
 
@@ -107,6 +111,7 @@ where
                 let client = Client::builder()
                     .cookie_provider(Arc::clone(&auth.jar))
                     .danger_accept_invalid_certs(should_allow_invalid_certs())
+                    .timeout(Duration::from_secs(60))
                     .build()
                     .context("Could not build client")?;
 
@@ -278,6 +283,7 @@ async fn login(server: &str, user: &str, password: &SecretString) -> Result<Arc<
     let client = Client::builder()
         .cookie_provider(Arc::clone(&jar))
         .danger_accept_invalid_certs(should_allow_invalid_certs())
+        .timeout(Duration::from_secs(60))
         .build()
         .context("Could not build client")?;
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -333,6 +333,11 @@ impl Job {
     }
 
     #[getter]
+    fn is_duplicate(&self) -> PyResult<bool> {
+        Ok(self.0.is_duplicate())
+    }
+
+    #[getter]
     fn state(&self) -> PyResult<Status> {
         Ok(self.0.state().into())
     }
@@ -1569,6 +1574,11 @@ impl Status {
     #[staticmethod]
     fn error() -> PyResult<Status> {
         Ok(Status(job::Status::Error))
+    }
+
+    #[staticmethod]
+    fn duplicate() -> PyResult<Status> {
+        Ok(Status(job::Status::Duplicate))
     }
 }
 

--- a/slurm/src/main.rs
+++ b/slurm/src/main.rs
@@ -125,7 +125,7 @@ async fn main() -> Result<()> {
 
                 match job.instruction() {
                     AddLocalProject(project) => {
-                        sacctmgr::add_project(&project).await?;
+                        sacctmgr::add_project(&project, job.expires()).await?;
                         job.completed_none()
                     },
                     RemoveLocalProject(project) => {
@@ -136,7 +136,7 @@ async fn main() -> Result<()> {
                         job.completed_none()
                     },
                     AddLocalUser(user) => {
-                        sacctmgr::add_user(&user).await?;
+                        sacctmgr::add_user(&user, job.expires()).await?;
                         job.completed_none()
                     },
                     RemoveLocalUser(mapping) => {
@@ -148,15 +148,15 @@ async fn main() -> Result<()> {
                         job.completed_none()
                     },
                     GetLocalUsageReport(mapping, dates) => {
-                        let report = sacctmgr::get_usage_report(&mapping, &dates).await?;
+                        let report = sacctmgr::get_usage_report(&mapping, &dates, job.expires()).await?;
                         job.completed(report)
                     }
                     GetLocalLimit(mapping) => {
-                        let limit = sacctmgr::get_limit(&mapping).await?;
+                        let limit = sacctmgr::get_limit(&mapping, job.expires()).await?;
                         job.completed(limit)
                     }
                     SetLocalLimit(mapping, limit) => {
-                        let limit = sacctmgr::set_limit(&mapping, &limit).await?;
+                        let limit = sacctmgr::set_limit(&mapping, &limit, job.expires()).await?;
                         job.completed(limit)
                     }
                     _ => {
@@ -218,7 +218,7 @@ async fn main() -> Result<()> {
 
                 match job.instruction() {
                     AddLocalProject(project) => {
-                        slurm::add_project(&project).await?;
+                        slurm::add_project(&project, job.expires()).await?;
                         job.completed_none()
                     },
                     RemoveLocalProject(project) => {
@@ -229,7 +229,7 @@ async fn main() -> Result<()> {
                         job.completed_none()
                     },
                     AddLocalUser(user) => {
-                        slurm::add_user(&user).await?;
+                        slurm::add_user(&user, job.expires()).await?;
                         job.completed_none()
                     },
                     RemoveLocalUser(mapping) => {
@@ -242,15 +242,15 @@ async fn main() -> Result<()> {
                     },
                     GetLocalUsageReport(mapping, dates) => {
                         // use sacctmgr for now, as we need to validate the API response
-                        let report = slurm::get_usage_report(&mapping, &dates).await?;
+                        let report = slurm::get_usage_report(&mapping, &dates, job.expires()).await?;
                         job.completed(report)
                     }
                     GetLocalLimit(mapping) => {
-                        let limit = slurm::get_limit(&mapping).await?;
+                        let limit = slurm::get_limit(&mapping, job.expires()).await?;
                         job.completed(limit)
                     }
                     SetLocalLimit(mapping, limit) => {
-                        let limit = slurm::set_limit(&mapping, &limit).await?;
+                        let limit = slurm::set_limit(&mapping, &limit, job.expires()).await?;
                         job.completed(limit)
                     }
                     _ => {

--- a/slurm/src/slurm.rs
+++ b/slurm/src/slurm.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::Display;
+use std::time::Duration;
 use templemeads::grammar::{DateRange, ProjectMapping, UserMapping};
 use templemeads::usagereport::{DailyProjectUsageReport, ProjectUsageReport, Usage};
 use templemeads::Error;
@@ -100,6 +101,7 @@ async fn call_get(
     tracing::debug!("Calling function {}", url);
 
     let client = Client::builder()
+        .timeout(Duration::from_secs(60))
         .build()
         .context("Could not build client")?;
 
@@ -144,6 +146,7 @@ async fn call_get(
 
                 // create a new client with the new cookies
                 let client = Client::builder()
+                    .timeout(Duration::from_secs(60))
                     .build()
                     .context("Could not build client")?;
 
@@ -299,6 +302,7 @@ async fn call_post(
     tracing::debug!("Calling function {} with payload: {:?}", url, payload);
 
     let client = Client::builder()
+        .timeout(Duration::from_secs(60))
         .build()
         .context("Could not build client")?;
 
@@ -344,6 +348,7 @@ async fn call_post(
 
                 // create a new client with the new cookies
                 let client = Client::builder()
+                    .timeout(Duration::from_secs(60))
                     .build()
                     .context("Could not build client")?;
 
@@ -568,6 +573,7 @@ async fn login(
 
     // create a client
     let client = Client::builder()
+        .timeout(Duration::from_secs(60))
         .build()
         .context("Could not build client")?;
 

--- a/slurm/src/slurm.rs
+++ b/slurm/src/slurm.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Context;
 use anyhow::Result;
-use chrono::TimeZone;
+use chrono::{TimeZone, Utc};
 use once_cell::sync::Lazy;
 use reqwest::{Client, Url};
 use secrecy::{ExposeSecret, SecretString};
@@ -13,9 +13,10 @@ use std::fmt;
 use std::fmt::Display;
 use std::time::Duration;
 use templemeads::grammar::{DateRange, ProjectMapping, UserMapping};
+use templemeads::job::assert_not_expired;
 use templemeads::usagereport::{DailyProjectUsageReport, ProjectUsageReport, Usage};
 use templemeads::Error;
-use tokio::sync::{Mutex, MutexGuard};
+use tokio::sync::{Mutex, MutexGuard, Semaphore};
 
 use crate::cache;
 use crate::sacctmgr;
@@ -2917,7 +2918,17 @@ pub async fn connect(
     }
 }
 
-pub async fn add_user(user: &UserMapping) -> Result<(), Error> {
+static MAX_CONCURRENT_REQUESTS: Lazy<Semaphore> = Lazy::new(|| Semaphore::new(10));
+
+pub async fn add_user(user: &UserMapping, expires: &chrono::DateTime<Utc>) -> Result<(), Error> {
+    // ensure that we don't have too many concurrent requests
+    let _permit = MAX_CONCURRENT_REQUESTS
+        .acquire()
+        .await
+        .map_err(|_| Error::Call("Failed to acquire semaphore for adding a user".to_string()))?;
+
+    assert_not_expired(expires)?;
+
     // get a lock for this user, as only a single task should be adding
     // or removing this user at the same time
     let now = chrono::Utc::now();
@@ -2950,7 +2961,18 @@ pub async fn add_user(user: &UserMapping) -> Result<(), Error> {
     Ok(())
 }
 
-pub async fn add_project(project: &ProjectMapping) -> Result<(), Error> {
+pub async fn add_project(
+    project: &ProjectMapping,
+    expires: &chrono::DateTime<Utc>,
+) -> Result<(), Error> {
+    // ensure that we don't have too many concurrent requests
+    let _permit = MAX_CONCURRENT_REQUESTS
+        .acquire()
+        .await
+        .map_err(|_| Error::Call("Failed to acquire semaphore for adding a project".to_string()))?;
+
+    assert_not_expired(expires)?;
+
     // get a lock for this project, as only a single task should be adding
     // or removing this project at the same time
     let now = chrono::Utc::now();
@@ -2991,7 +3013,15 @@ pub async fn add_project(project: &ProjectMapping) -> Result<(), Error> {
 pub async fn get_usage_report(
     project: &ProjectMapping,
     dates: &DateRange,
+    expires: &chrono::DateTime<Utc>,
 ) -> Result<ProjectUsageReport, Error> {
+    // ensure that we don't have too many concurrent requests
+    let _permit = MAX_CONCURRENT_REQUESTS.acquire().await.map_err(|_| {
+        Error::Call("Failed to acquire semaphore for getting the usage report".to_string())
+    })?;
+
+    assert_not_expired(expires)?;
+
     let account = SlurmAccount::from_mapping(project)?;
 
     let account = match get_account(account.name()).await {
@@ -3100,7 +3130,17 @@ pub async fn get_usage_report(
     Ok(report)
 }
 
-pub async fn get_limit(project: &ProjectMapping) -> Result<Usage, Error> {
+pub async fn get_limit(
+    project: &ProjectMapping,
+    expires: &chrono::DateTime<Utc>,
+) -> Result<Usage, Error> {
+    // ensure that we don't have too many concurrent requests
+    let _permit = MAX_CONCURRENT_REQUESTS.acquire().await.map_err(|_| {
+        Error::Call("Failed to acquire semaphore for getting the limit".to_string())
+    })?;
+
+    assert_not_expired(expires)?;
+
     let account = SlurmAccount::from_mapping(project)?;
 
     let account = match get_account(account.name()).await? {
@@ -3238,7 +3278,18 @@ pub async fn get_limit(project: &ProjectMapping) -> Result<Usage, Error> {
     Ok(*account.limit())
 }
 
-pub async fn set_limit(project: &ProjectMapping, limit: &Usage) -> Result<Usage, Error> {
+pub async fn set_limit(
+    project: &ProjectMapping,
+    limit: &Usage,
+    expires: &chrono::DateTime<Utc>,
+) -> Result<Usage, Error> {
+    // ensure that we don't have too many concurrent requests
+    let _permit = MAX_CONCURRENT_REQUESTS.acquire().await.map_err(|_| {
+        Error::Call("Failed to acquire semaphore for setting the limit".to_string())
+    })?;
+
+    assert_not_expired(expires)?;
+
     let account = SlurmAccount::from_mapping(project)?;
 
     match get_account(account.name()).await? {

--- a/templemeads/src/board.rs
+++ b/templemeads/src/board.rs
@@ -11,6 +11,18 @@ use crate::command::Command as ControlCommand;
 use crate::error::Error;
 use crate::job::Job;
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum JobAddState {
+    /// The job was added to the board
+    Added,
+    /// The job was already on the board, but it was updated
+    Updated,
+    /// The job was added to the board, but it is a duplicate of an existing job
+    Duplicated,
+    /// The job was not added because it was already on the board
+    Unchanged,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct SyncState {
     jobs: Vec<Job>,
@@ -134,21 +146,21 @@ impl Board {
     ///
     /// The indicated board for the job must match the name of this board
     ///
-    /// This returns whether or not the board has changed
-    /// (i.e. whether the job is not already on the board with this
-    ///  version)
+    /// This returns the state change for the board, i.e.
+    /// if the job was added, updated, duplicated, or unchanged.
     ///
-    pub fn add(&mut self, job: &Job) -> Result<bool, Error> {
+    pub fn add(&mut self, job: &Job) -> Result<(Job, JobAddState), Error> {
         job.assert_is_for_board(&self.peer)?;
 
-        let mut updated = false;
+        let mut state = JobAddState::Unchanged;
+        let mut job = job.clone();
 
         match self.jobs.get_mut(&job.id()) {
             Some(j) => {
                 // only update if newer
                 if job.version() > j.version() {
                     *j = job.clone();
-                    updated = true;
+                    state = JobAddState::Updated;
                 }
                 // else if the job is newer, then automatically create a new version
                 else if job.changed() > j.changed() {
@@ -159,7 +171,8 @@ impl Board {
                         *j = j.increment_version();
                     }
 
-                    updated = true;
+                    job = j.clone();
+                    state = JobAddState::Updated;
                 }
             }
             None => {
@@ -168,17 +181,17 @@ impl Board {
                 // a problem, and job changes are idempotent (i.e.
                 // it doesn't matter if this happens twice)
                 self.jobs.insert(job.id(), job.clone());
-                updated = true;
+                state = JobAddState::Added;
             }
         }
 
         // if this is a new job then check for any duplicates
-        if updated && job.is_pending() {
+        if state == JobAddState::Added && job.is_pending() {
             // do through all of the existing jobs to see if there are
             // any others that are pending and have the same destination
             // and command
             for (id, existing_job) in &self.jobs.clone() {
-                if job.is_duplicate_of(existing_job) {
+                if *id != job.id() && job.is_duplicate_of(existing_job) {
                     // change the status of our job to be a duplicate
                     let duplicate = match job.duplicate(existing_job) {
                         Ok(dup) => dup,
@@ -188,18 +201,28 @@ impl Board {
                         }
                     };
 
+                    assert!(duplicate.is_duplicate());
+
                     // we now need to update this job to be a duplicate
                     self.jobs.insert(duplicate.id(), duplicate.clone());
 
                     // now record this as a duplicate for the original's ID
                     self.duplicates.entry(*id).or_default().push(duplicate.id());
+
+                    tracing::info!(
+                        "Number of duplicates for instruction {}: {}",
+                        duplicate.instruction(),
+                        self.duplicates.get(id).map_or(0, |v| v.len())
+                    );
+
+                    return Ok((duplicate, JobAddState::Duplicated));
                 }
             }
         }
 
         // if we have any waiters for this job then notify them if the
         // job has been updated and it is in a finished state
-        if updated && job.is_finished() {
+        if (state == JobAddState::Added || state == JobAddState::Updated) && job.is_finished() {
             if let Some(listeners) = self.waiters.remove(&job.id()) {
                 for listener in listeners {
                     listener.notify(job.clone());
@@ -209,20 +232,39 @@ impl Board {
             // if we have any duplicates for this job then we also
             // need to update those duplicates and notify their listeners
             if let Some(duplicate_ids) = self.duplicates.remove(&job.id()) {
+                tracing::info!(
+                    "Original finished: Updating {} duplicates for job {}",
+                    duplicate_ids.len(),
+                    job.id()
+                );
+
                 for duplicate_id in duplicate_ids {
                     if let Some(duplicate_job) = self.jobs.get_mut(&duplicate_id) {
                         // update the duplicate job to be finished
-                        *duplicate_job = match duplicate_job.copy_result_from(job) {
-                            Ok(dup) => dup,
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to copy result from job {}: {}",
-                                    job.id(),
-                                    e
-                                );
-                                duplicate_job.errored("Failed to copy result from original job")?
-                            }
-                        };
+                        if !duplicate_job.is_finished() {
+                            *duplicate_job = match duplicate_job.copy_result_from(&job) {
+                                Ok(dup) => dup,
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Failed to copy result from job {}: {}",
+                                        job.id(),
+                                        e
+                                    );
+                                    match duplicate_job
+                                        .errored("Failed to copy result from original job")
+                                    {
+                                        Ok(dup) => dup,
+                                        Err(e) => {
+                                            tracing::error!(
+                                                "Failed to mark duplicate job as errored: {}",
+                                                e
+                                            );
+                                            duplicate_job.clone()
+                                        }
+                                    }
+                                }
+                            };
+                        }
 
                         // notify any listeners for the duplicate job
                         if let Some(listeners) = self.waiters.remove(&duplicate_id) {
@@ -235,7 +277,7 @@ impl Board {
             }
         }
 
-        Ok(updated)
+        Ok((job, state))
     }
 
     ///
@@ -273,23 +315,31 @@ impl Board {
 
         if let Some(duplicate_ids) = self.duplicates.remove(&job.id()) {
             for duplicate_id in duplicate_ids {
-                if let Some(duplicate_job) = self.jobs.remove(&duplicate_id) {
-                    let duplicate_job = match duplicate_job.copy_result_from(job) {
-                        Ok(dup) => dup,
-                        Err(e) => {
-                            tracing::error!("Failed to copy result from job {}: {}", job.id(), e);
-                            match duplicate_job.errored("Failed to copy result from original job") {
-                                Ok(dup) => dup,
-                                Err(e) => {
-                                    tracing::error!(
-                                        "Failed to mark duplicate job as errored: {}",
-                                        e
-                                    );
-                                    duplicate_job
+                if let Some(mut duplicate_job) = self.jobs.remove(&duplicate_id) {
+                    if !duplicate_job.is_finished() {
+                        duplicate_job = match duplicate_job.copy_result_from(job) {
+                            Ok(dup) => dup,
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to copy result from job {}: {}",
+                                    job.id(),
+                                    e
+                                );
+                                match duplicate_job
+                                    .errored("Failed to copy result from original job")
+                                {
+                                    Ok(dup) => dup,
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to mark duplicate job as errored: {}",
+                                            e
+                                        );
+                                        duplicate_job
+                                    }
                                 }
                             }
-                        }
-                    };
+                        };
+                    }
 
                     // notify any listeners for the duplicate job
                     if let Some(listeners) = self.waiters.remove(&duplicate_id) {

--- a/templemeads/src/handler.rs
+++ b/templemeads/src/handler.rs
@@ -130,8 +130,6 @@ async fn process_command(
         Command::Put { job } => {
             let peer = Peer::new(sender, zone);
 
-            tracing::debug!("Put job: {} to {} from {}", job, recipient, peer,);
-
             // update the sender's board with the received job
             let mut job = match job.received(&peer).await {
                 Ok(job) => job,

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -767,7 +767,7 @@ impl Job {
                 // There is no need to send to the peer
                 // (the job has already been sent)
                 if job.is_duplicate() {
-                    tracing::info!("Not sending duplicate job: {:?}", job);
+                    tracing::info!("Not sending duplicate job: {}", job.instruction());
                 }
 
                 return Ok(job);

--- a/templemeads/src/job.rs
+++ b/templemeads/src/job.rs
@@ -337,6 +337,10 @@ impl Job {
         self.command.instruction()
     }
 
+    pub fn expires(&self) -> &chrono::DateTime<Utc> {
+        &self.expires
+    }
+
     pub fn set_lifetime(&self, lifetime: chrono::Duration) -> Self {
         Self {
             id: self.id,
@@ -1242,6 +1246,18 @@ pub async fn send_queued(peer: &Peer) -> Result<(), Error> {
         }
     }
 
+    Ok(())
+}
+
+///
+/// Assert that the job with the specified expiry time has not expired
+///
+pub fn assert_not_expired(expiry: &chrono::DateTime<Utc>) -> Result<(), Error> {
+    if Utc::now() > *expiry {
+        return Err(Error::Expired(
+            format!("Job expired at: {}", expiry).to_owned(),
+        ));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
- Added automatic de-duplication of jobs. Now, if the board detects
  that a job is added that is the same as one that is already being
  processed, it will automatically mark the new job as a "duplicate",
  and will not process it. Instead, it will copy the result from the
  already-running job and return that result once it is ready. In this
  way, we prevent job storms if a caller continually re-submits the
  same job without waiting for the result. Duplicate jobs are caught
  in the communication chain, so will not be sent on to downstream
  peers. This makes the system more responsive and robust, as
  now only new jobs are processed downstream, with duplicates
  filtered out at a high level.

- Added passing of the job expiry time to the functions called by
  the slurm and freeipa agents. Now, these agents will abort any
  functions calls that take too long and that whose results would
  be ignored anyway as the calling job had expired. This prevents
  resource starvation and denial of service / deadlocks caused
  by floods of long-running jobs blocking the system, and causing
  all new jobs to timeout or run slowly.

- Added a semaphore to the function calls of the slurm and freeipa
  agents. This semaphore ensures that only 10 jobs can be processed
  at the same time. This reduces contention pressure on the
  (serialised) access to the freeipa / slurm REST APIs, or to
  running saact/mgr commands. This prevents a deadlock situation
  where a single function calls the API or runs the command
  one after the other, but gets blocked by a storm of new
  jobs that hold that resource in the first call to the API
  or command. In this case, all of the jobs would be blocking
  each other on the first call, preventing any from making
  subsequent calls, and thus the jobs expire (but the function
  call would keep going). Now, only 10 function calls can be
  made in parallel, which will reduce contention and ensure
  that they can complete before job expiry. This, combined with
  checking the job expiry time, should prevent flooding
  of the system, and creating of long chains / queues of jobs
  that never complete.

- Added timeouts to REST API calls and for running external
  commands. These timeouts (60 seconds) ensure that if any
  command or REST call takes too long, then they will be terminated
  and an error returned. This is important, as calling a REST
  API or running a command is serialised (held behind a mutex)
  to ensure that OpenPortal doesn't flood downstream services
  (OpenPortal only makes one FreeIPA rest call, or one SLURM
  call at a time). Previously, a failure of, e.g. FreeIPA,
  could cause the freeipa agent to hang indefinitely, as the
  REST API call would never return. Now, if the call takes
  longer than 60 seconds, it will be aborted, and an error
  returned. This, combined with all of the changes described
  above should make the whole OpenPortal more robust
  and resilient to errors and job storms.