### PR TITLE
Add manylinux aarch64 wheel build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,6 +23,8 @@ jobs:
         platform:
           - runner: ubuntu-latest
             target: x86_64
+          - runner: ubuntu-latest
+            target: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,7 +23,7 @@ jobs:
         platform:
           - runner: ubuntu-latest
             target: x86_64
-          - runner: ubuntu-latest
+          - runner: ubuntu-24.04-arm
             target: aarch64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The linux job only builds `manylinux_2_17_x86_64` glibc wheels. ARM64 Linux users with glibc-based distributions (Debian, Ubuntu, RHEL on ARM, Docker `buildx` arm64 builds) cannot install the package via pip because only `musllinux_1_1_aarch64` wheels are available — and those are incompatible with glibc systems.

This causes errors like:
```
error: Distribution `openportal==0.26.0` can't be installed because it doesn't have a 
source distribution or wheel for the current platform

hint: You're on Linux (`manylinux_2_41_aarch64`), but `openportal` (v0.26.0) only has 
wheels for: `manylinux_2_17_x86_64`, `manylinux2014_x86_64`, `musllinux_1_1_aarch64`, 
`musllinux_1_1_x86_64`, `macosx_11_0_arm64`
```

## Fix

Add `aarch64` to the linux job matrix in `python.yml`, using the native `ubuntu-24.04-arm` runner which is free for public repos. No cross-compilation needed.

## Change

```diff
 platform:
   - runner: ubuntu-latest
     target: x86_64
+  - runner: ubuntu-24.04-arm
+    target: aarch64
```